### PR TITLE
Add RustOps.{sigmoid,swish}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a21b9440a626c7fc8573a9e3d3a06b75c7c97754c2949bc7857b90353ca655"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "autocfg"
@@ -139,6 +175,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +314,12 @@ checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
 dependencies = [
  "rawpointer",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "ndarray"
@@ -439,12 +500,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -474,17 +564,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
 name = "rust-ops"
 version = "0.1.0"
 dependencies = [
  "accelerate-src",
+ "aligned",
  "anyhow",
+ "approx",
+ "as-slice",
  "blis-src",
  "intel-mkl-src",
  "ndarray",
  "num-traits",
  "numpy",
  "pyo3",
+ "quickcheck",
 ]
 
 [[package]]
@@ -533,6 +644,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 accelerate-src = { version = "0.3", optional = true }
+aligned = "0.4"
+as-slice = "0.2"
 ndarray = { version = "0.15", features = ["blas"] }
 num-traits = "0.2"
 numpy = "0.16"
@@ -26,6 +28,10 @@ intel-mkl-src = { version = "0.6" }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
 blis-src = { version = "0.2", default-features = false, features = ["serial", "cblas", "static"] }
+
+[dev-dependencies]
+approx = "0.5"
+quickcheck = "1"
 
 [package.metadata.maturin]
 python-source = "python"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    check_avx();
+}
+
+#[cfg(target_arch = "x86_64")]
+fn check_avx() {
+    if is_x86_feature_detected!("avx") {
+        println!("cargo:rustc-cfg=feature=\"test_avx\"");
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn check_avx() {}

--- a/python/rust_ops/__init__.py
+++ b/python/rust_ops/__init__.py
@@ -16,19 +16,3 @@ class RustOps(_RustOps, NumpyOps):
     def __init__(self, device_type: DeviceTypes = "cpu", device_id: int = -1):
         self.device_type = device_type
         self.device_id = device_id
-
-
-    # Remove once https://github.com/explosion/thinc/pull/709 is merged and we
-    # have a Thinc version with this change. Patching sigmoid here to make sure
-    # that we can pass tests.
-    def sigmoid(self, X: FloatsType, *, inplace: bool = False) -> FloatsType:
-        if inplace:
-            # To prevent overflows and help with regularization/numerical stability
-            X = self.xp.clip(X, -20.0, 20.0, out=X)
-            self.xp.exp(-X, out=X)
-            X += 1.0  # type: ignore[assignment]
-            X **= -1.0  # type: ignore[assignment]
-            return cast(FloatsType, X)
-        else:
-            X = self.xp.clip(X, -20.0, 20.0)
-            return cast(FloatsType, 1.0 / (1.0 + self.xp.exp(-X)))

--- a/src/elementary.rs
+++ b/src/elementary.rs
@@ -1,0 +1,156 @@
+use num_traits::{Float, FloatConst, NumCast, One, Zero};
+
+use crate::simd::vector::{FloatingPointProps, SimdVector};
+
+mod fastexp_poly_coeff {
+    // Constants from Malossi et al., 2015
+    pub const POLY_COEFF_5_0: f64 = 1.068_237_537_102_394_8e-7;
+    pub const POLY_COEFF_5_1: f64 = 3.068_452_496_566_328_5e-1;
+    pub const POLY_COEFF_5_2: f64 = -2.401_397_219_822_308e-1;
+    pub const POLY_COEFF_5_3: f64 = -5.586_622_824_128_225e-2;
+    pub const POLY_COEFF_5_4: f64 = -8.942_838_909_312_74e-3;
+    pub const POLY_COEFF_5_5: f64 = -1.896_460_523_807_077_3e-3;
+}
+
+pub trait Elementary {
+    type Float;
+    unsafe fn exp(x: Self::Float) -> Self::Float;
+}
+
+impl<V> Elementary for V
+where
+    V: SimdVector,
+{
+    type Float = V::Float;
+
+    unsafe fn exp(mut x: Self::Float) -> Self::Float {
+        let inf = V::splat(V::FloatScalar::infinity());
+        let zero = V::splat(V::FloatScalar::zero());
+
+        let coeff_a = <V::FloatScalar as NumCast>::from(
+            V::IntScalar::one() << V::FloatScalar::mantissa_bits(),
+        )
+        .unwrap();
+        let coeff_b = <V::FloatScalar as NumCast>::from(
+            (V::IntScalar::one() << V::FloatScalar::mantissa_bits())
+                * <V::IntScalar as NumCast>::from(V::FloatScalar::bias()).unwrap(),
+        )
+        .unwrap();
+        let poly_coeff_5_0 =
+            <V::FloatScalar as NumCast>::from(fastexp_poly_coeff::POLY_COEFF_5_0).unwrap();
+        let poly_coeff_5_1 =
+            <V::FloatScalar as NumCast>::from(fastexp_poly_coeff::POLY_COEFF_5_1).unwrap();
+        let poly_coeff_5_2 =
+            <V::FloatScalar as NumCast>::from(fastexp_poly_coeff::POLY_COEFF_5_2).unwrap();
+        let poly_coeff_5_3 =
+            <V::FloatScalar as NumCast>::from(fastexp_poly_coeff::POLY_COEFF_5_3).unwrap();
+        let poly_coeff_5_4 =
+            <V::FloatScalar as NumCast>::from(fastexp_poly_coeff::POLY_COEFF_5_4).unwrap();
+        let poly_coeff_5_5 =
+            <V::FloatScalar as NumCast>::from(fastexp_poly_coeff::POLY_COEFF_5_5).unwrap();
+
+        // Maximum positive value.
+        let max_mask = V::gt(x, V::splat(V::FloatScalar::max_value().ln()));
+
+        // Smallest positive normalized value.
+        let smallest_positive_mask = V::lt(x, V::splat(V::FloatScalar::min_positive_value().ln()));
+
+        // Elements that are not NaN.
+        let not_nan = V::eq(x, x);
+
+        x = V::mul_scalar(x, V::FloatScalar::LOG2_E());
+        let xf = V::sub(x, V::floor(x));
+
+        let mut factor = V::splat(poly_coeff_5_5);
+        factor = V::add_scalar(V::mul(factor, xf), poly_coeff_5_4);
+        factor = V::add_scalar(V::mul(factor, xf), poly_coeff_5_3);
+        factor = V::add_scalar(V::mul(factor, xf), poly_coeff_5_2);
+        factor = V::add_scalar(V::mul(factor, xf), poly_coeff_5_1);
+        factor = V::add_scalar(V::mul(factor, xf), poly_coeff_5_0);
+
+        x = V::sub(x, factor);
+
+        //let cast = V::to_int(V::add_scalar(V::mul_scalar(x, coeff_a), coeff_b));
+        let cast = V::to_int(V::add_scalar(V::mul_scalar(x, coeff_a), coeff_b));
+
+        x = V::reinterpret_float_signed(cast);
+
+        x = V::bitwise_select(max_mask, inf, x);
+        x = V::bitwise_select(smallest_positive_mask, zero, x);
+        V::bitwise_select(not_nan, x, V::splat(V::FloatScalar::nan()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    use approx::relative_eq;
+    use as_slice::AsSlice;
+    use num_traits::{Float, ToPrimitive};
+    use quickcheck::quickcheck;
+
+    use super::Elementary;
+    #[cfg(feature = "test_avx")]
+    use crate::simd::vector::avx::{AVX32, AVX64};
+    #[cfg(target_arch = "aarch64")]
+    use crate::simd::vector::neon::{NeonVector32, NeonVector64};
+    use crate::simd::vector::{ScalarVector32, ScalarVector64, SimdVector};
+
+    fn exp_close_to_std_exp<S>(v: S::FloatScalar) -> bool
+    where
+        S: SimdVector,
+    {
+        let check_exp = v.exp();
+        let r = {
+            unsafe {
+                S::to_float_scalar_array(S::exp(S::splat(v))).as_slice()[0]
+                    .to_f64()
+                    .unwrap()
+            }
+        };
+        assert_eq!(r.is_nan(), check_exp.is_nan());
+        if v.is_nan() {
+            return true;
+        }
+
+        let max_relative = if mem::size_of::<S::FloatScalar>() == 4 {
+            // 1e-5 fails sometimes in many repetitions of the test, e.g.: 51.304375
+            1e-4
+        } else {
+            1e-6
+        };
+
+        relative_eq!(r, check_exp.to_f64().unwrap(), max_relative = max_relative)
+    }
+
+    quickcheck! {
+        fn scalar_exp_close_to_std_exp_f32(v: f32) -> bool {
+            exp_close_to_std_exp::<ScalarVector32>(v)
+        }
+
+        fn scalar_exp_close_to_std_exp_f64(v: f64) -> bool {
+            exp_close_to_std_exp::<ScalarVector64>(v)
+        }
+
+        #[cfg(feature = "test_avx")]
+        fn avx_exp_close_to_std_exp_f32(v: f32) -> bool {
+            exp_close_to_std_exp::<AVX32>(v)
+        }
+
+        #[cfg(feature = "test_avx")]
+        fn avx_exp_close_to_std_exp_f64(v: f64) -> bool {
+            exp_close_to_std_exp::<AVX64>(v)
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        fn neon_exp_close_to_std_exp_f32(v: f32) -> bool {
+            exp_close_to_std_exp::<NeonVector32>(v)
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        fn neon_exp_close_to_std_exp_f64(v: f64) -> bool {
+            exp_close_to_std_exp::<NeonVector64>(v)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use pyo3::{pymodule, PyResult, Python};
 mod ops;
 use ops::RustOps;
 
+mod elementary;
+
 pub(crate) mod simd;
 
 #[pymodule]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -169,6 +169,22 @@ impl RustOps {
             |s| self.array_f64.relu(s),
         )
     }
+
+    #[args(inplace = "false")]
+    fn sigmoid<'py>(
+        &self,
+        py: Python<'py>,
+        x: PyArrayDynFloat<'py>,
+        inplace: bool,
+    ) -> PyResult<PyArrayDynFloat<'py>> {
+        Self::elementwise_op(
+            py,
+            x,
+            inplace,
+            |s| self.array_f32.logistic_function(s),
+            |s| self.array_f64.logistic_function(s),
+        )
+    }
 }
 
 impl RustOps {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -35,8 +35,8 @@ impl<'a> IntoPy<PyObject> for PyArrayDynFloat<'a> {
 
 #[pyclass(subclass)]
 pub struct RustOps {
-    array_f32: Box<dyn Array<f32>>,
-    array_f64: Box<dyn Array<f64>>,
+    array_f32: Box<dyn Array<Scalar = f32>>,
+    array_f64: Box<dyn Array<Scalar = f64>>,
 }
 
 #[pymethods]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -185,6 +185,22 @@ impl RustOps {
             |s| self.array_f64.logistic_function(s),
         )
     }
+
+    #[args(inplace = "false")]
+    fn swish<'py>(
+        &self,
+        py: Python<'py>,
+        x: PyArrayDynFloat<'py>,
+        inplace: bool,
+    ) -> PyResult<PyArrayDynFloat<'py>> {
+        Self::elementwise_op(
+            py,
+            x,
+            inplace,
+            |s| self.array_f32.swish(s),
+            |s| self.array_f64.swish(s),
+        )
+    }
 }
 
 impl RustOps {

--- a/src/simd/activation.rs
+++ b/src/simd/activation.rs
@@ -7,6 +7,8 @@ pub trait Activation {
     type Float;
 
     unsafe fn logistic_function(x: Self::Float) -> Self::Float;
+
+    unsafe fn swish(x: Self::Float) -> Self::Float;
 }
 
 impl<V, T> Activation for V
@@ -19,5 +21,9 @@ where
     unsafe fn logistic_function(x: Self::Float) -> Self::Float {
         let one = V::splat(<V::FloatScalar as NumCast>::from(1.0).unwrap());
         V::div(one, V::add(V::exp(V::neg(x)), one))
+    }
+
+    unsafe fn swish(x: Self::Float) -> Self::Float {
+        V::mul(x, Self::logistic_function(x))
     }
 }

--- a/src/simd/activation.rs
+++ b/src/simd/activation.rs
@@ -1,0 +1,23 @@
+use num_traits::NumCast;
+
+use crate::elementary::Elementary;
+use crate::simd::vector::SimdVector;
+
+pub trait Activation {
+    type Float;
+
+    unsafe fn logistic_function(x: Self::Float) -> Self::Float;
+}
+
+impl<V, T> Activation for V
+where
+    T: Copy,
+    V: SimdVector<Float = T> + Elementary<Float = T>,
+{
+    type Float = <V as SimdVector>::Float;
+
+    unsafe fn logistic_function(x: Self::Float) -> Self::Float {
+        let one = V::splat(<V::FloatScalar as NumCast>::from(1.0).unwrap());
+        V::div(one, V::add(V::exp(V::neg(x)), one))
+    }
+}

--- a/src/simd/array.rs
+++ b/src/simd/array.rs
@@ -57,6 +57,8 @@ pub trait Array: Send + Sync {
     fn logistic_function(&self, a: &mut [Self::Scalar]);
 
     fn relu(&self, a: &mut [Self::Scalar]);
+
+    fn swish(&self, a: &mut [Self::Scalar]);
 }
 
 impl<V, T> Array for V
@@ -126,6 +128,13 @@ where
         unsafe {
             let zero = V::splat(Self::Scalar::zero());
             V::apply_elementwise(|v| V::vmax(v, zero), |a| smaller.relu(a), a);
+        }
+    }
+
+    fn swish(&self, a: &mut [Self::Scalar]) {
+        let smaller = V::Lower::default();
+        unsafe {
+            V::apply_elementwise(|v| V::swish(v), |a| smaller.swish(a), a);
         }
     }
 }

--- a/src/simd/array.rs
+++ b/src/simd/array.rs
@@ -1,53 +1,76 @@
-use num_traits::Float;
 #[cfg(target_arch = "aarch64")]
 use std::arch::is_aarch64_feature_detected;
+use std::ops::Neg;
+
+use num_traits::{NumCast, One, Zero};
 
 #[cfg(target_arch = "x86_64")]
-use crate::simd::vector::avx::AVXVector;
+use crate::simd::vector::avx::AVX32;
+#[cfg(target_arch = "x86_64")]
+use crate::simd::vector::avx::AVX64;
 #[cfg(target_arch = "aarch64")]
-use crate::simd::vector::neon::NeonVector;
-use crate::simd::vector::{ScalarVector, SimdVector};
+use crate::simd::vector::neon::NeonVector32;
+#[cfg(target_arch = "aarch64")]
+use crate::simd::vector::neon::NeonVector64;
+use crate::simd::vector::{ScalarVector32, ScalarVector64, SimdVector};
 
 #[cfg(target_arch = "aarch64")]
-pub fn platform_arrays() -> (Box<dyn Array<f32>>, Box<dyn Array<f64>>) {
+pub fn platform_arrays() -> (Box<dyn Array<Scalar = f32>>, Box<dyn Array<Scalar = f64>>) {
     if is_aarch64_feature_detected!("neon") {
-        (Box::new(NeonVector), Box::new(NeonVector))
+        (Box::new(NeonVector32), Box::new(NeonVector64))
     } else {
-        (Box::new(ScalarVector), Box::new(ScalarVector))
+        (Box::new(ScalarVector32), Box::new(ScalarVector64))
     }
 }
 
 #[cfg(target_arch = "x86_64")]
-pub fn platform_arrays() -> (Box<dyn Array<f32>>, Box<dyn Array<f64>>) {
+pub fn platform_arrays() -> (Box<dyn Array<Scalar = f32>>, Box<dyn Array<Scalar = f64>>) {
     if is_x86_feature_detected!("avx") {
-        (Box::new(AVXVector), Box::new(AVXVector))
+        (Box::new(AVX32), Box::new(AVX64))
     } else {
-        (Box::new(ScalarVector), Box::new(ScalarVector))
+        (Box::new(ScalarVector32), Box::new(ScalarVector64))
     }
 }
 
 #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-pub fn platform_arrays() -> (Box<dyn Array<f32>>, Box<dyn Array<f64>>) {
-    (Box::new(ScalarVector), Box::new(ScalarVector))
+pub fn platform_arrays() -> (Box<dyn Array<Scalar = f32>>, Box<dyn Array<Scalar = f64>>) {
+    (Box::new(ScalarVector32), Box::new(ScalarVector64))
 }
 
-pub trait Array<T>: Send + Sync {
-    fn clipped_linear(&self, a: &mut [T], slope: T, offset: T, min_val: T, max_val: T);
+pub trait Array: Send + Sync {
+    type Scalar;
 
-    fn hard_sigmoid(&self, a: &mut [T]);
+    fn clipped_linear(
+        &self,
+        a: &mut [Self::Scalar],
+        slope: Self::Scalar,
+        offset: Self::Scalar,
+        min_val: Self::Scalar,
+        max_val: Self::Scalar,
+    );
 
-    fn hard_tanh(&self, a: &mut [T]);
+    fn hard_sigmoid(&self, a: &mut [Self::Scalar]);
 
-    fn relu(&self, a: &mut [T]);
+    fn hard_tanh(&self, a: &mut [Self::Scalar]);
+
+    fn relu(&self, a: &mut [Self::Scalar]);
 }
 
-impl<T, V> Array<T> for V
+impl<V> Array for V
 where
-    T: Float,
-    V: SimdVector<T>,
+    V: SimdVector,
 {
-    fn clipped_linear(&self, a: &mut [T], slope: T, offset: T, min_val: T, max_val: T) {
-        let smaller = V::Lower::default();
+    type Scalar = V::FloatScalar;
+
+    fn clipped_linear(
+        &self,
+        a: &mut [Self::Scalar],
+        slope: Self::Scalar,
+        offset: Self::Scalar,
+        min_val: Self::Scalar,
+        max_val: Self::Scalar,
+    ) {
+        let lower = V::Lower::default();
         unsafe {
             let v_min_val = V::splat(min_val);
             let v_max_val = V::splat(max_val);
@@ -57,36 +80,36 @@ where
                     let v = V::add_scalar(V::mul_scalar(v, slope), offset);
                     V::vmin(V::vmax(v, v_min_val), v_max_val)
                 },
-                |a| smaller.clipped_linear(a, slope, offset, min_val, max_val),
+                |a| lower.clipped_linear(a, slope, offset, min_val, max_val),
                 a,
             )
         }
     }
 
-    fn hard_sigmoid(&self, a: &mut [T]) {
+    fn hard_sigmoid(&self, a: &mut [Self::Scalar]) {
         self.clipped_linear(
             a,
-            T::from(0.2).unwrap(),
-            T::from(0.5).unwrap(),
-            T::zero(),
-            T::one(),
+            <Self::Scalar as NumCast>::from(0.2).unwrap(),
+            <Self::Scalar as NumCast>::from(0.5).unwrap(),
+            Self::Scalar::zero(),
+            Self::Scalar::one(),
         )
     }
 
-    fn hard_tanh(&self, a: &mut [T]) {
+    fn hard_tanh(&self, a: &mut [Self::Scalar]) {
         self.clipped_linear(
             a,
-            T::from(1.).unwrap(),
-            T::from(0.).unwrap(),
-            T::one().neg(),
-            T::one(),
+            <Self::Scalar as NumCast>::from(1.).unwrap(),
+            <Self::Scalar as NumCast>::from(0.).unwrap(),
+            Self::Scalar::one().neg(),
+            Self::Scalar::one(),
         )
     }
 
-    fn relu(&self, a: &mut [T]) {
+    fn relu(&self, a: &mut [Self::Scalar]) {
         let smaller = V::Lower::default();
         unsafe {
-            let zero = V::splat(T::zero());
+            let zero = V::splat(Self::Scalar::zero());
             V::apply_elementwise(|v| V::vmax(v, zero), |a| smaller.relu(a), a);
         }
     }

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod activation;
+
 mod array;
 pub(crate) mod vector;
 

--- a/src/simd/vector.rs
+++ b/src/simd/vector.rs
@@ -1,48 +1,129 @@
+use std::borrow::Borrow;
 use std::mem;
 
-pub trait SimdVector<T>: Default + Send + Sync {
-    type Lower: SimdVector<T>;
-    type Type: Copy;
+use num_traits::{Float, PrimInt};
+
+pub trait FloatingPointProps {
+    fn bias() -> usize;
+    fn mantissa_bits() -> usize;
+}
+
+impl FloatingPointProps for f32 {
+    fn bias() -> usize {
+        127
+    }
+
+    fn mantissa_bits() -> usize {
+        23
+    }
+}
+
+impl FloatingPointProps for f64 {
+    fn bias() -> usize {
+        1023
+    }
+
+    fn mantissa_bits() -> usize {
+        52
+    }
+}
+
+pub trait SimdVector: Default + Send + Sync {
+    type Lower: SimdVector<FloatScalar = Self::FloatScalar>;
+    type Float: Copy;
+    type FloatScalar: Float + FloatingPointProps;
+    type FloatScalarArray: Borrow<[Self::FloatScalar]>;
+    type Int: Copy;
+    type IntScalar: PrimInt;
+
+    unsafe fn add(a: Self::Float, b: Self::Float) -> Self::Float;
 
     /// Add a scalar to every vector element.
-    unsafe fn add_scalar(a: Self::Type, b: T) -> Self::Type;
+    unsafe fn add_scalar(a: Self::Float, b: Self::FloatScalar) -> Self::Float;
+
+    unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float;
+
+    /// Round to largest integers lower than or equal to the given numbers.
+    unsafe fn floor(a: Self::Float) -> Self::Float;
+
+    /// Vector element-wise multiplication.
+    unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float;
 
     /// Multiply every vector element by a scalar.
-    unsafe fn mul_scalar(a: Self::Type, b: T) -> Self::Type;
+    unsafe fn mul_scalar(a: Self::Float, b: Self::FloatScalar) -> Self::Float;
+
+    unsafe fn neg(a: Self::Float) -> Self::Float;
+
+    unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float;
 
     /// Vector element-wise maximum.
-    unsafe fn vmax(a: Self::Type, b: Self::Type) -> Self::Type;
+    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float;
 
     /// Vector element-wise minimum.
-    unsafe fn vmin(a: Self::Type, b: Self::Type) -> Self::Type;
+    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float;
 
-    unsafe fn splat(v: T) -> Self::Type;
+    unsafe fn splat(v: Self::FloatScalar) -> Self::Float;
 
-    unsafe fn with_load_store(f: &impl Fn(Self::Type) -> Self::Type, a: &mut [T]);
+    unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float;
+
+    unsafe fn to_int(v: Self::Float) -> Self::Int;
+
+    unsafe fn to_float_scalar_array(v: Self::Float) -> Self::FloatScalarArray;
+
+    unsafe fn with_load_store(f: &impl Fn(Self::Float) -> Self::Float, a: &mut [Self::FloatScalar]);
 
     unsafe fn apply_elementwise(
-        f: impl Fn(Self::Type) -> Self::Type,
-        f_rest: impl Fn(&mut [T]),
-        a: &mut [T],
+        f: impl Fn(Self::Float) -> Self::Float,
+        f_rest: impl Fn(&mut [Self::FloatScalar]),
+        a: &mut [Self::FloatScalar],
     );
 }
 
 #[derive(Default)]
-pub struct ScalarVector;
+pub struct ScalarVector32;
 
-impl SimdVector<f32> for ScalarVector {
-    type Lower = ScalarVector;
-    type Type = f32;
+impl SimdVector for ScalarVector32 {
+    type Lower = ScalarVector32;
+    type Float = f32;
+    type FloatScalar = f32;
+    type FloatScalarArray =
+        [Self::FloatScalar; mem::size_of::<Self::Float>() / mem::size_of::<Self::FloatScalar>()];
+    type Int = i32;
+    type IntScalar = i32;
 
-    unsafe fn add_scalar(a: Self::Type, b: f32) -> Self::Type {
+    unsafe fn add(a: Self::Float, b: Self::Float) -> Self::Float {
         a + b
     }
 
-    unsafe fn mul_scalar(a: Self::Type, b: f32) -> Self::Type {
+    unsafe fn add_scalar(a: Self::Float, b: f32) -> Self::Float {
+        a + b
+    }
+
+    unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float {
+        a / b
+    }
+
+    unsafe fn floor(a: Self::Float) -> Self::Float {
+        a.floor()
+    }
+
+    unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         a * b
     }
 
-    unsafe fn vmax(a: Self::Type, b: Self::Type) -> Self::Type {
+    unsafe fn mul_scalar(a: Self::Float, b: f32) -> Self::Float {
+        a * b
+    }
+
+    unsafe fn neg(a: Self::Float) -> Self::Float {
+        -a
+    }
+
+    unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float {
+        a - b
+    }
+
+    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
         if a > b {
             a
         } else {
@@ -50,7 +131,7 @@ impl SimdVector<f32> for ScalarVector {
         }
     }
 
-    unsafe fn vmin(a: Self::Type, b: Self::Type) -> Self::Type {
+    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
         if a > b {
             b
         } else {
@@ -58,16 +139,28 @@ impl SimdVector<f32> for ScalarVector {
         }
     }
 
-    unsafe fn splat(v: f32) -> Self::Type {
+    unsafe fn splat(v: f32) -> Self::Float {
         v
     }
 
-    unsafe fn with_load_store(f: &impl Fn(Self::Type) -> Self::Type, a: &mut [f32]) {
+    unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float {
+        Self::Float::from_bits(v as u32)
+    }
+
+    unsafe fn to_int(v: Self::Float) -> Self::Int {
+        v as Self::Int
+    }
+
+    unsafe fn to_float_scalar_array(v: Self::Float) -> Self::FloatScalarArray {
+        [v]
+    }
+
+    unsafe fn with_load_store(f: &impl Fn(Self::Float) -> Self::Float, a: &mut [f32]) {
         a[0] = f(a[0])
     }
 
     unsafe fn apply_elementwise(
-        f: impl Fn(Self::Type) -> Self::Type,
+        f: impl Fn(Self::Float) -> Self::Float,
         f_rest: impl Fn(&mut [f32]),
         a: &mut [f32],
     ) {
@@ -76,26 +169,58 @@ impl SimdVector<f32> for ScalarVector {
     }
 }
 
-impl SimdVector<f64> for ScalarVector {
-    type Lower = ScalarVector;
-    type Type = f64;
+#[derive(Default)]
+pub struct ScalarVector64;
 
-    unsafe fn add_scalar(a: Self::Type, b: f64) -> Self::Type {
+impl SimdVector for ScalarVector64 {
+    type Lower = ScalarVector64;
+    type Float = f64;
+    type FloatScalar = f64;
+    type FloatScalarArray =
+        [Self::FloatScalar; mem::size_of::<Self::Float>() / mem::size_of::<Self::FloatScalar>()];
+    type Int = i64;
+    type IntScalar = i64;
+
+    unsafe fn add(a: Self::Float, b: Self::Float) -> Self::Float {
         a + b
     }
 
-    unsafe fn mul_scalar(a: Self::Type, b: f64) -> Self::Type {
+    unsafe fn add_scalar(a: Self::Float, b: f64) -> Self::Float {
+        a + b
+    }
+
+    unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float {
+        a / b
+    }
+
+    unsafe fn floor(a: Self::Float) -> Self::Float {
+        a.floor()
+    }
+
+    unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         a * b
     }
 
-    unsafe fn vmax(a: Self::Type, b: Self::Type) -> Self::Type {
+    unsafe fn mul_scalar(a: Self::Float, b: f64) -> Self::Float {
+        a * b
+    }
+
+    unsafe fn neg(a: Self::Float) -> Self::Float {
+        -a
+    }
+
+    unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float {
+        a - b
+    }
+
+    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
         if a > b {
             a
         } else {
             b
         }
     }
-    unsafe fn vmin(a: Self::Type, b: Self::Type) -> Self::Type {
+    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
         if a > b {
             b
         } else {
@@ -103,16 +228,28 @@ impl SimdVector<f64> for ScalarVector {
         }
     }
 
-    unsafe fn splat(v: f64) -> Self::Type {
+    unsafe fn splat(v: f64) -> Self::Float {
         v
     }
 
-    unsafe fn with_load_store(f: &impl Fn(Self::Type) -> Self::Type, a: &mut [f64]) {
+    unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float {
+        mem::transmute::<Self::Int, Self::Float>(v)
+    }
+
+    unsafe fn to_int(v: Self::Float) -> Self::Int {
+        v as Self::Int
+    }
+
+    unsafe fn to_float_scalar_array(v: Self::Float) -> Self::FloatScalarArray {
+        [v]
+    }
+
+    unsafe fn with_load_store(f: &impl Fn(Self::Float) -> Self::Float, a: &mut [f64]) {
         a[0] = f(a[0])
     }
 
     unsafe fn apply_elementwise(
-        f: impl Fn(Self::Type) -> Self::Type,
+        f: impl Fn(Self::Float) -> Self::Float,
         f_rest: impl Fn(&mut [f64]),
         a: &mut [f64],
     ) {
@@ -123,44 +260,85 @@ impl SimdVector<f64> for ScalarVector {
 
 #[cfg(all(target_arch = "x86_64"))]
 pub mod avx {
+    use crate::simd::vector::ScalarVector64;
+    use num_traits::Float;
     use std::arch::x86_64::{
-        __m256, __m256d, _mm256_add_pd, _mm256_add_ps, _mm256_load_pd, _mm256_loadu_ps,
-        _mm256_max_pd, _mm256_max_ps, _mm256_min_pd, _mm256_min_ps, _mm256_mul_pd, _mm256_mul_ps,
-        _mm256_set1_pd, _mm256_set1_ps, _mm256_store_pd, _mm256_storeu_ps,
+        __m256, __m256d, __m256i, _mm256_add_pd, _mm256_add_ps, _mm256_castpd_si256,
+        _mm256_castsi256_pd, _mm256_castsi256_ps, _mm256_cvtps_epi32, _mm256_div_pd, _mm256_div_ps,
+        _mm256_floor_pd, _mm256_floor_ps, _mm256_load_pd, _mm256_loadu_ps, _mm256_max_pd,
+        _mm256_max_ps, _mm256_min_pd, _mm256_min_ps, _mm256_mul_pd, _mm256_mul_ps, _mm256_set1_pd,
+        _mm256_set1_ps, _mm256_store_pd, _mm256_storeu_ps, _mm256_sub_epi64, _mm256_sub_pd,
+        _mm256_sub_ps, _mm256_xor_pd, _mm256_xor_ps,
     };
 
-    use super::{ScalarVector, SimdVector};
+    use super::{ScalarVector32, SimdVector};
 
     #[derive(Default)]
-    pub struct AVXVector;
+    pub struct AVX32;
 
-    impl SimdVector<f32> for AVXVector {
-        type Lower = ScalarVector;
-        type Type = __m256;
+    impl SimdVector for AVX32 {
+        type Lower = ScalarVector32;
+        type Float = __m256;
+        type FloatScalar = f32;
+        type Int = __m256i;
+        type IntScalar = i32;
 
-        unsafe fn add_scalar(a: Self::Type, b: f32) -> Self::Type {
+        unsafe fn add(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_add_ps(a, b)
+        }
+
+        unsafe fn add_scalar(a: Self::Float, b: f32) -> Self::Float {
             let b_simd = _mm256_set1_ps(b);
             _mm256_add_ps(a, b_simd)
         }
 
-        unsafe fn mul_scalar(a: Self::Type, b: f32) -> Self::Type {
+        unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_div_ps(a, b)
+        }
+
+        unsafe fn floor(a: Self::Float) -> Self::Float {
+            _mm256_floor_ps(a)
+        }
+
+        unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_mul_ps(a, b)
+        }
+
+        unsafe fn mul_scalar(a: Self::Float, b: f32) -> Self::Float {
             let b_simd = _mm256_set1_ps(b);
             _mm256_mul_ps(a, b_simd)
         }
 
-        unsafe fn vmax(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn neg(a: Self::Float) -> Self::Float {
+            let neg_zero = _mm256_set1_ps(Self::FloatScalar::neg_zero());
+            _mm256_xor_ps(a, neg_zero)
+        }
+
+        unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_sub_ps(a, b)
+        }
+
+        unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
             _mm256_max_ps(a, b)
         }
 
-        unsafe fn vmin(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
             _mm256_min_ps(a, b)
         }
 
-        unsafe fn splat(v: f32) -> Self::Type {
+        unsafe fn splat(v: f32) -> Self::Float {
             _mm256_set1_ps(v)
         }
 
-        unsafe fn with_load_store(f: &impl Fn(Self::Type) -> Self::Type, a: &mut [f32]) {
+        unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float {
+            _mm256_castsi256_ps(v)
+        }
+
+        unsafe fn to_int(v: Self::Float) -> Self::Int {
+            _mm256_cvtps_epi32(v)
+        }
+
+        unsafe fn with_load_store(f: &impl Fn(Self::Float) -> Self::Float, a: &mut [f32]) {
             let mut val = _mm256_loadu_ps(a.as_ptr());
             val = f(val);
             _mm256_storeu_ps(a.as_mut_ptr(), val);
@@ -168,7 +346,7 @@ pub mod avx {
 
         #[target_feature(enable = "avx")]
         unsafe fn apply_elementwise(
-            f: impl Fn(Self::Type) -> Self::Type,
+            f: impl Fn(Self::Float) -> Self::Float,
             f_rest: impl Fn(&mut [f32]),
             a: &mut [f32],
         ) {
@@ -177,41 +355,84 @@ pub mod avx {
         }
     }
 
-    impl SimdVector<f64> for AVXVector {
-        type Lower = ScalarVector;
-        type Type = __m256d;
+    #[derive(Default)]
+    pub struct AVX64;
 
-        unsafe fn add_scalar(a: Self::Type, b: f64) -> Self::Type {
+    impl SimdVector for AVX64 {
+        type Lower = ScalarVector64;
+        type Float = __m256d;
+        type FloatScalar = f64;
+        type Int = __m256i;
+        type IntScalar = i64;
+
+        unsafe fn add(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_add_pd(a, b)
+        }
+
+        unsafe fn add_scalar(a: Self::Float, b: f64) -> Self::Float {
             let b_simd = _mm256_set1_pd(b);
             _mm256_add_pd(a, b_simd)
         }
 
-        unsafe fn mul_scalar(a: Self::Type, b: f64) -> Self::Type {
+        unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_div_pd(a, b)
+        }
+
+        unsafe fn floor(a: Self::Float) -> Self::Float {
+            _mm256_floor_pd(a)
+        }
+
+        unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_mul_pd(a, b)
+        }
+
+        unsafe fn mul_scalar(a: Self::Float, b: f64) -> Self::Float {
             let b_simd = _mm256_set1_pd(b);
             _mm256_mul_pd(a, b_simd)
         }
 
-        unsafe fn vmax(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn neg(a: Self::Float) -> Self::Float {
+            let neg_zero = _mm256_set1_pd(Self::FloatScalar::neg_zero());
+            _mm256_xor_pd(a, neg_zero)
+        }
+
+        unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float {
+            _mm256_sub_pd(a, b)
+        }
+
+        unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
             _mm256_max_pd(a, b)
         }
 
-        unsafe fn vmin(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
             _mm256_min_pd(a, b)
         }
 
-        unsafe fn splat(v: f64) -> Self::Type {
+        unsafe fn splat(v: f64) -> Self::Float {
             _mm256_set1_pd(v)
         }
 
-        unsafe fn with_load_store(f: &impl Fn(Self::Type) -> Self::Type, a: &mut [f64]) {
-            let mut val = _mm256_load_pd(a.as_ptr());
+        unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float {
+            _mm256_castsi256_pd(v)
+        }
+
+        unsafe fn to_int(v: Self::Float) -> Self::Int {
+            // Blegh, no instruction for this before AVX-512.
+            let mut data_f64 = [0f64; 4];
+            _mm256_storeu_pd(data_f64.as_mut_ptr(), v);
+            let data = data_f64.map(|v| v as i64);
+            _mm256_loadu_si256(data.as_ptr().cast())
+        }
+
+        unsafe fn with_load_store(f: &impl Fn(Self::Float) -> Self::Float, a: &mut [f64]) {
+            let mut val = _mm256_loadu_pd(a.as_ptr());
             val = f(val);
-            _mm256_store_pd(a.as_mut_ptr(), val);
+            _mm256_storeu_pd(a.as_mut_ptr(), val);
         }
 
         #[target_feature(enable = "avx")]
         unsafe fn apply_elementwise(
-            f: impl Fn(Self::Type) -> Self::Type,
+            f: impl Fn(Self::Float) -> Self::Float,
             f_rest: impl Fn(&mut [f64]),
             a: &mut [f64],
         ) {
@@ -224,50 +445,97 @@ pub mod avx {
 #[cfg(all(target_arch = "aarch64"))]
 pub mod neon {
     use std::arch::aarch64::{
-        float32x4_t, float64x2_t, vaddq_f32, vaddq_f64, vdupq_n_f32, vdupq_n_f64, vld1q_f32,
-        vld1q_f64, vmaxq_f32, vmaxq_f64, vminq_f32, vminq_f64, vmulq_f32, vmulq_f64, vst1q_f32,
-        vst1q_f64,
+        float32x4_t, float64x2_t, int32x4_t, int64x2_t, vaddq_f32, vaddq_f64, vcvtq_s32_f32,
+        vcvtq_s64_f64, vdivq_f32, vdivq_f64, vdupq_n_f32, vdupq_n_f64, vld1q_f32, vld1q_f64,
+        vmaxq_f32, vmaxq_f64, vminq_f32, vminq_f64, vmulq_f32, vmulq_f64, vnegq_f32, vnegq_f64,
+        vreinterpretq_f32_s32, vreinterpretq_f64_s64, vrndmq_f32, vrndmq_f64, vst1q_f32, vst1q_f64,
+        vsubq_f32, vsubq_f64,
     };
+    use std::mem;
 
-    use super::{ScalarVector, SimdVector};
+    use super::{ScalarVector32, SimdVector};
+    use crate::simd::vector::ScalarVector64;
 
     #[derive(Default)]
-    pub struct NeonVector;
+    pub struct NeonVector32;
 
-    impl SimdVector<f32> for NeonVector {
-        type Lower = ScalarVector;
-        type Type = float32x4_t;
+    impl SimdVector for NeonVector32 {
+        type Lower = ScalarVector32;
+        type Float = float32x4_t;
+        type FloatScalar = f32;
+        type FloatScalarArray = [Self::FloatScalar;
+            mem::size_of::<Self::Float>() / mem::size_of::<Self::FloatScalar>()];
+        type Int = int32x4_t;
+        type IntScalar = i32;
 
-        unsafe fn add_scalar(a: Self::Type, b: f32) -> Self::Type {
+        unsafe fn add(a: Self::Float, b: Self::Float) -> Self::Float {
+            vaddq_f32(a, b)
+        }
+
+        unsafe fn add_scalar(a: Self::Float, b: f32) -> Self::Float {
             let b_simd = vdupq_n_f32(b);
             vaddq_f32(a, b_simd)
         }
 
-        unsafe fn mul_scalar(a: Self::Type, b: f32) -> Self::Type {
+        unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float {
+            vdivq_f32(a, b)
+        }
+
+        unsafe fn floor(a: Self::Float) -> Self::Float {
+            vrndmq_f32(a)
+        }
+
+        unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
+            vmulq_f32(a, b)
+        }
+
+        unsafe fn mul_scalar(a: Self::Float, b: f32) -> Self::Float {
             let b_simd = vdupq_n_f32(b);
             vmulq_f32(a, b_simd)
         }
 
-        unsafe fn vmax(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn neg(a: Self::Float) -> Self::Float {
+            vnegq_f32(a)
+        }
+
+        unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float {
+            vsubq_f32(a, b)
+        }
+
+        unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
             vmaxq_f32(a, b)
         }
 
-        unsafe fn vmin(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
             vminq_f32(a, b)
         }
 
-        unsafe fn splat(v: f32) -> Self::Type {
+        unsafe fn splat(v: f32) -> Self::Float {
             vdupq_n_f32(v)
         }
 
-        unsafe fn with_load_store(f: &impl Fn(Self::Type) -> Self::Type, a: &mut [f32]) {
+        unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float {
+            vreinterpretq_f32_s32(v)
+        }
+
+        unsafe fn to_int(v: Self::Float) -> Self::Int {
+            vcvtq_s32_f32(v)
+        }
+
+        unsafe fn to_float_scalar_array(v: Self::Float) -> Self::FloatScalarArray {
+            let mut a = [0f32; 4];
+            vst1q_f32(a.as_mut_ptr(), v);
+            a
+        }
+
+        unsafe fn with_load_store(f: &impl Fn(Self::Float) -> Self::Float, a: &mut [f32]) {
             let mut val = vld1q_f32(a.as_ptr());
             val = f(val);
             vst1q_f32(a.as_mut_ptr(), val)
         }
 
         unsafe fn apply_elementwise(
-            f: impl Fn(Self::Type) -> Self::Type,
+            f: impl Fn(Self::Float) -> Self::Float,
             f_rest: impl Fn(&mut [f32]),
             a: &mut [f32],
         ) {
@@ -276,40 +544,86 @@ pub mod neon {
         }
     }
 
-    impl SimdVector<f64> for NeonVector {
-        type Lower = ScalarVector;
-        type Type = float64x2_t;
+    #[derive(Default)]
+    pub struct NeonVector64;
 
-        unsafe fn add_scalar(a: Self::Type, b: f64) -> Self::Type {
+    impl SimdVector for NeonVector64 {
+        type Lower = ScalarVector64;
+        type Float = float64x2_t;
+        type FloatScalar = f64;
+        type FloatScalarArray = [Self::FloatScalar;
+            mem::size_of::<Self::Float>() / mem::size_of::<Self::FloatScalar>()];
+        type Int = int64x2_t;
+        type IntScalar = i64;
+
+        unsafe fn add(a: Self::Float, b: Self::Float) -> Self::Float {
+            vaddq_f64(a, b)
+        }
+
+        unsafe fn add_scalar(a: Self::Float, b: f64) -> Self::Float {
             let b_simd = vdupq_n_f64(b);
             vaddq_f64(a, b_simd)
         }
 
-        unsafe fn mul_scalar(a: Self::Type, b: f64) -> Self::Type {
+        unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float {
+            vdivq_f64(a, b)
+        }
+
+        unsafe fn floor(a: Self::Float) -> Self::Float {
+            vrndmq_f64(a)
+        }
+
+        unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
+            vmulq_f64(a, b)
+        }
+
+        unsafe fn mul_scalar(a: Self::Float, b: f64) -> Self::Float {
             let b_simd = vdupq_n_f64(b);
             vmulq_f64(a, b_simd)
         }
 
-        unsafe fn vmax(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn neg(a: Self::Float) -> Self::Float {
+            vnegq_f64(a)
+        }
+
+        unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float {
+            vsubq_f64(a, b)
+        }
+
+        unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
             vmaxq_f64(a, b)
         }
 
-        unsafe fn vmin(a: Self::Type, b: Self::Type) -> Self::Type {
+        unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
             vminq_f64(a, b)
         }
 
-        unsafe fn splat(v: f64) -> Self::Type {
+        unsafe fn splat(v: f64) -> Self::Float {
             vdupq_n_f64(v)
         }
 
-        unsafe fn with_load_store(f: &impl Fn(Self::Type) -> Self::Type, a: &mut [f64]) {
+        unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float {
+            vreinterpretq_f64_s64(v)
+        }
+
+        unsafe fn to_int(v: Self::Float) -> Self::Int {
+            vcvtq_s64_f64(v)
+        }
+
+        unsafe fn to_float_scalar_array(v: Self::Float) -> Self::FloatScalarArray {
+            let mut a = [0f64; 2];
+            vst1q_f64(a.as_mut_ptr(), v);
+            a
+        }
+
+        unsafe fn with_load_store(f: &impl Fn(Self::Float) -> Self::Float, a: &mut [f64]) {
             let mut val = vld1q_f64(a.as_ptr());
             val = f(val);
             vst1q_f64(a.as_mut_ptr(), val)
         }
 
         unsafe fn apply_elementwise(
-            f: impl Fn(Self::Type) -> Self::Type,
+            f: impl Fn(Self::Float) -> Self::Float,
             f_rest: impl Fn(&mut [f64]),
             a: &mut [f64],
         ) {
@@ -320,15 +634,15 @@ pub mod neon {
 }
 
 // TODO: get rid of the first argument. Needed so far to help type inference.
-unsafe fn apply_elementwise_generic<T, V>(
+unsafe fn apply_elementwise_generic<V>(
     _v: &V,
-    f: impl Fn(V::Type) -> V::Type,
-    f_rest: impl Fn(&mut [T]),
-    mut a: &mut [T],
+    f: impl Fn(V::Float) -> V::Float,
+    f_rest: impl Fn(&mut [V::FloatScalar]),
+    mut a: &mut [V::FloatScalar],
 ) where
-    V: SimdVector<T>,
+    V: SimdVector,
 {
-    let elem_size = mem::size_of::<V::Type>() / mem::size_of::<T>();
+    let elem_size = mem::size_of::<V::Float>() / mem::size_of::<V::FloatScalar>();
 
     while a.len() >= elem_size {
         V::with_load_store(&f, a);


### PR DESCRIPTION
In order to support these functions, implement a SIMD version of the `exp` elementary function. To properly support everything, do a major refactor of the SIMD set-up.