### PR TITLE
Move simd module to a new `simd-array` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "aligned"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,15 +22,6 @@ name = "anyhow"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
-
-[[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "as-slice"
@@ -175,16 +157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,12 +248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "libm"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,15 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,12 +277,6 @@ checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
 dependencies = [
  "rawpointer",
 ]
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "ndarray"
@@ -506,41 +457,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "env_logger",
- "log",
- "rand",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -570,39 +492,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
-
-[[package]]
 name = "rust-ops"
 version = "0.1.0"
 dependencies = [
  "accelerate-src",
- "aligned",
  "anyhow",
- "approx",
- "as-slice",
  "blis-src",
  "intel-mkl-src",
- "libm",
  "ndarray",
- "num-traits",
  "numpy",
  "pyo3",
- "quickcheck",
+ "simd-array",
 ]
 
 [[package]]
@@ -635,6 +535,15 @@ name = "semver"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+
+[[package]]
+name = "simd-array"
+version = "0.1.0"
+dependencies = [
+ "aligned",
+ "as-slice",
+ "num-traits",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 accelerate-src = { version = "0.3", optional = true }
-aligned = "0.4"
-as-slice = "0.2"
 ndarray = { version = "0.15", features = ["blas"] }
-num-traits = "0.2"
 numpy = "0.16"
 pyo3 = { version = "0.16", features = ["extension-module", "abi3", "abi3-py37"] }
+simd-array = { path = "simd-array" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3" }
@@ -28,11 +26,6 @@ intel-mkl-src = { version = "0.6" }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
 blis-src = { version = "0.2", default-features = false, features = ["serial", "cblas", "static"] }
-
-[dev-dependencies]
-approx = "0.5"
-libm = "0.2"
-quickcheck = "1"
 
 [package.metadata.maturin]
 python-source = "python"

--- a/simd-array/Cargo.toml
+++ b/simd-array/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "simd-array"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+aligned = "0.4"
+as-slice = "0.2"
+num-traits = "0.2"
+
+[dev-dependencies]
+approx = "0.5"
+libm = "0.2"
+quickcheck = "1"

--- a/simd-array/src/activation.rs
+++ b/simd-array/src/activation.rs
@@ -1,9 +1,9 @@
-use crate::simd::distribution::Distribution;
 use num_traits::{NumCast, One, Zero};
 use std::ops::Neg;
 
-use crate::simd::elementary::Elementary;
-use crate::simd::vector::SimdVector;
+use crate::distribution::Distribution;
+use crate::elementary::Elementary;
+use crate::vector::SimdVector;
 
 pub trait Activation {
     type Float;

--- a/simd-array/src/array.rs
+++ b/simd-array/src/array.rs
@@ -1,19 +1,19 @@
 #[cfg(target_arch = "aarch64")]
 use std::arch::is_aarch64_feature_detected;
 
-use crate::simd::activation::Activation;
-use crate::simd::distribution::Distribution;
 use num_traits::Float;
 
+use crate::activation::Activation;
+use crate::distribution::Distribution;
 #[cfg(target_arch = "x86_64")]
-use crate::simd::vector::avx::AVXVector32;
+use crate::vector::avx::AVXVector32;
 #[cfg(target_arch = "x86_64")]
-use crate::simd::vector::avx::AVXVector64;
+use crate::vector::avx::AVXVector64;
 #[cfg(target_arch = "aarch64")]
-use crate::simd::vector::neon::NeonVector32;
+use crate::vector::neon::NeonVector32;
 #[cfg(target_arch = "aarch64")]
-use crate::simd::vector::neon::NeonVector64;
-use crate::simd::vector::{ScalarVector32, ScalarVector64, SimdVector};
+use crate::vector::neon::NeonVector64;
+use crate::vector::{ScalarVector32, ScalarVector64, SimdVector};
 
 #[cfg(target_arch = "aarch64")]
 pub fn platform_arrays() -> (Box<dyn Array<Scalar = f32>>, Box<dyn Array<Scalar = f64>>) {

--- a/simd-array/src/distribution.rs
+++ b/simd-array/src/distribution.rs
@@ -1,7 +1,7 @@
 use num_traits::{FloatConst, NumCast, One};
 
-use crate::simd::elementary::Elementary;
-use crate::simd::vector::SimdVector;
+use crate::elementary::Elementary;
+use crate::vector::SimdVector;
 
 pub trait Distribution {
     type Float;

--- a/simd-array/src/elementary.rs
+++ b/simd-array/src/elementary.rs
@@ -1,6 +1,6 @@
 use num_traits::{Float, FloatConst, NumCast, One, Zero};
 
-use crate::simd::vector::{FloatingPointProps, SimdVector};
+use crate::vector::{FloatingPointProps, SimdVector};
 
 mod fasterf_poly_coeff {
     // Constants and approximation from Abramowitz and Stegun, 1964.
@@ -130,10 +130,10 @@ mod tests {
 
     use super::Elementary;
     #[cfg(feature = "test_avx")]
-    use crate::simd::vector::avx::{AVXVector32, AVXVector64};
+    use crate::vector::avx::{AVXVector32, AVXVector64};
     #[cfg(target_arch = "aarch64")]
-    use crate::simd::vector::neon::{NeonVector32, NeonVector64};
-    use crate::simd::vector::{ScalarVector32, ScalarVector64, SimdVector};
+    use crate::vector::neon::{NeonVector32, NeonVector64};
+    use crate::vector::{ScalarVector32, ScalarVector64, SimdVector};
 
     fn erf_close_to_libm_erf<S>(v: S::FloatScalar) -> bool
     where

--- a/simd-array/src/lib.rs
+++ b/simd-array/src/lib.rs
@@ -1,7 +1,7 @@
 pub(crate) mod activation;
 
 mod array;
-pub(crate) use array::{platform_arrays, Array};
+pub use array::{platform_arrays, Array};
 
 mod distribution;
 

--- a/simd-array/src/vector.rs
+++ b/simd-array/src/vector.rs
@@ -368,7 +368,7 @@ pub mod avx {
     use std::ops::Neg;
 
     use super::{ScalarVector32, SimdVector};
-    use crate::simd::vector::ScalarVector64;
+    use crate::vector::ScalarVector64;
     use num_traits::{Float, Zero};
 
     #[derive(Default)]
@@ -640,7 +640,7 @@ pub mod neon {
     use std::ops::Neg;
 
     use super::{ScalarVector32, SimdVector};
-    use crate::simd::vector::ScalarVector64;
+    use crate::vector::ScalarVector64;
 
     #[derive(Default)]
     pub struct NeonVector32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ use pyo3::{pymodule, PyResult, Python};
 mod ops;
 use ops::RustOps;
 
-pub(crate) mod simd;
-
 #[pymodule]
 fn rust_ops(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<RustOps>()?;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3,7 +3,7 @@ use numpy::{PyArray2, PyArrayDyn, PyReadonlyArray2};
 use pyo3::exceptions::PyValueError;
 use pyo3::{pyclass, pymethods, FromPyObject, IntoPy, PyObject, PyResult, Python};
 
-use crate::simd::{platform_arrays, Array};
+use simd_array::{platform_arrays, Array};
 
 #[derive(FromPyObject)]
 enum PyArrayDynFloat<'a> {


### PR DESCRIPTION
Having the SIMD array code in a separate crate makes our life a bit easier, since e.g. benchmarks are not supported in a `cdylib` project.