### PR TITLE
Fix exp overflow

### DIFF
--- a/simd-array/src/elementary.rs
+++ b/simd-array/src/elementary.rs
@@ -85,7 +85,7 @@ where
         let poly_coeff_5_5 = V::from_f64(fastexp_poly_coeff::POLY_COEFF_5_5);
 
         // Maximum positive value.
-        let max_mask = V::gt(x, V::splat(V::FloatScalar::max_value().ln()));
+        let max_mask = V::gt(x, V::splat(V::FloatScalar::max_ln()));
 
         // Smallest positive normalized value.
         let smallest_positive_mask = V::lt(x, V::splat(V::FloatScalar::min_positive_value().ln()));

--- a/simd-array/src/vector.rs
+++ b/simd-array/src/vector.rs
@@ -6,7 +6,10 @@ use num_traits::{Float, FloatConst, NumCast, PrimInt};
 
 pub trait FloatingPointProps {
     fn bias() -> usize;
+
     fn mantissa_bits() -> usize;
+
+    fn max_ln() -> Self;
 }
 
 impl FloatingPointProps for f32 {
@@ -17,6 +20,10 @@ impl FloatingPointProps for f32 {
     fn mantissa_bits() -> usize {
         23
     }
+
+    fn max_ln() -> Self {
+        2f32.powi(f32::MAX_EXP - 1).ln()
+    }
 }
 
 impl FloatingPointProps for f64 {
@@ -26,6 +33,10 @@ impl FloatingPointProps for f64 {
 
     fn mantissa_bits() -> usize {
         52
+    }
+
+    fn max_ln() -> Self {
+        2f64.powi(f64::MAX_EXP - 1).ln()
     }
 }
 


### PR DESCRIPTION
We used the natural logarithm of the max value of the floating point type. Use the natural logarithm of the largest possible power of 2 instead.