### PR TITLE
Subclass AppleOps when available

### DIFF
--- a/python/rust_ops/__init__.py
+++ b/python/rust_ops/__init__.py
@@ -1,15 +1,26 @@
-from typing import TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 import numpy
-from thinc.api import NumpyOps
+from thinc.api import NumpyOps, Ops
 from thinc.types import Xp, DeviceTypes, FloatsXd
 
 from .rust_ops import RustOps as _RustOps
 
 
+if TYPE_CHECKING:
+    _Ops = Ops
+else:
+    try:
+        from thinc_apple_ops import AppleOps
+
+        _Ops = AppleOps
+    except ImportError:
+        _Ops = NumpyOps
+
+
 FloatsType = TypeVar("FloatsType", bound=FloatsXd)
 
 
-class RustOps(_RustOps, NumpyOps):
+class RustOps(_RustOps, _Ops):
     name = "rust"
     xp: Xp = numpy
 


### PR DESCRIPTION
This should only be needed temporarily. RustOps already uses Accelerate for `Ops.gemm`. If we would also populate the CBlas struct, we do not need AppleOps anymore.

Fixes #26.
