### PR TITLE
Make SIMDVector::vmax NaN-propagating

### DIFF
--- a/simd-array/src/activation.rs
+++ b/simd-array/src/activation.rs
@@ -47,7 +47,7 @@ where
         let x_min_val = V::splat(min_val);
         let x_max_val = V::splat(max_val);
         let x = V::add_scalar(V::mul_scalar(x, slope), offset);
-        V::vmin(V::max(x, x_min_val), x_max_val)
+        V::vmin(V::clamp_min(x, x_min_val), x_max_val)
     }
 
     #[inline(always)]
@@ -80,7 +80,7 @@ where
     #[inline(always)]
     unsafe fn relu(x: Self::Float) -> Self::Float {
         let zero = V::splat(V::FloatScalar::zero());
-        V::max(x, zero)
+        V::clamp_min(x, zero)
     }
 
     #[inline(always)]

--- a/simd-array/src/activation.rs
+++ b/simd-array/src/activation.rs
@@ -47,7 +47,7 @@ where
         let x_min_val = V::splat(min_val);
         let x_max_val = V::splat(max_val);
         let x = V::add_scalar(V::mul_scalar(x, slope), offset);
-        V::vmin(V::vmax(x, x_min_val), x_max_val)
+        V::vmin(V::max(x, x_min_val), x_max_val)
     }
 
     #[inline(always)]
@@ -80,7 +80,7 @@ where
     #[inline(always)]
     unsafe fn relu(x: Self::Float) -> Self::Float {
         let zero = V::splat(V::FloatScalar::zero());
-        V::vmax(x, zero)
+        V::max(x, zero)
     }
 
     #[inline(always)]

--- a/simd-array/src/vector/avx.rs
+++ b/simd-array/src/vector/avx.rs
@@ -65,6 +65,11 @@ impl SimdVector for AVXVector32 {
     }
 
     #[target_feature(enable = "avx")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        _mm256_max_ps(min, a)
+    }
+
+    #[target_feature(enable = "avx")]
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float {
         // Negative zero has all bits unset, except the sign bit.
         let sign_bit_mask = Self::splat(Self::FloatScalar::zero().neg());
@@ -232,6 +237,11 @@ impl SimdVector for AVXVector64 {
         let u = _mm256_and_pd(a, b);
         let v = _mm256_andnot_pd(a, c);
         _mm256_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "avx")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        _mm256_max_pd(min, a)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/avx.rs
+++ b/simd-array/src/vector/avx.rs
@@ -7,7 +7,7 @@ use std::arch::x86_64::{
     _mm256_max_ps, _mm256_min_pd, _mm256_min_ps, _mm256_mul_pd, _mm256_mul_ps, _mm256_or_pd,
     _mm256_or_ps, _mm256_set1_epi32, _mm256_set1_epi64x, _mm256_set1_pd, _mm256_set1_ps,
     _mm256_store_pd, _mm256_store_ps, _mm256_storeu_pd, _mm256_storeu_ps, _mm256_sub_pd,
-    _mm256_sub_ps, _mm256_xor_pd, _mm256_xor_ps, _CMP_EQ_OQ, _CMP_GT_OQ, _CMP_LT_OQ,
+    _mm256_sub_ps, _mm256_xor_pd, _mm256_xor_ps, _CMP_EQ_OQ, _CMP_GT_OQ, _CMP_LT_OQ, _CMP_UNORD_Q,
 };
 use std::mem;
 use std::ops::Neg;
@@ -129,8 +129,10 @@ impl SimdVector for AVXVector32 {
     }
 
     #[target_feature(enable = "avx")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_max_ps(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        let max = _mm256_max_ps(a, b);
+        let is_nan = _mm256_cmp_ps::<_CMP_UNORD_Q>(a, b);
+        _mm256_or_ps(max, is_nan)
     }
 
     #[target_feature(enable = "avx")]
@@ -297,8 +299,10 @@ impl SimdVector for AVXVector64 {
     }
 
     #[target_feature(enable = "avx")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_max_pd(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        let max = _mm256_max_pd(a, b);
+        let is_nan = _mm256_cmp_pd::<_CMP_UNORD_Q>(a, b);
+        _mm256_or_pd(max, is_nan)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/avx2.rs
+++ b/simd-array/src/vector/avx2.rs
@@ -65,6 +65,11 @@ impl SimdVector for AVX2Vector32 {
         _mm256_or_ps(u, v)
     }
 
+    #[target_feature(enable = "avx")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        AVXVector32::clamp_min(a, min)
+    }
+
     #[target_feature(enable = "avx2")]
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float {
         // Negative zero has all bits unset, except the sign bit.
@@ -231,6 +236,11 @@ impl SimdVector for AVX2Vector64 {
         let u = _mm256_and_pd(a, b);
         let v = _mm256_andnot_pd(a, c);
         _mm256_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "avx")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        AVXVector64::clamp_min(a, min)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/avx2.rs
+++ b/simd-array/src/vector/avx2.rs
@@ -4,11 +4,10 @@ use std::arch::x86_64::{
     _mm256_castsi256_pd, _mm256_castsi256_ps, _mm256_cmp_pd, _mm256_cmp_ps, _mm256_cvtps_epi32,
     _mm256_div_pd, _mm256_div_ps, _mm256_extractf128_pd, _mm256_extractf128_ps, _mm256_floor_pd,
     _mm256_floor_ps, _mm256_fmadd_pd, _mm256_fmadd_ps, _mm256_load_si256, _mm256_loadu_pd,
-    _mm256_loadu_ps, _mm256_max_pd, _mm256_max_ps, _mm256_min_pd, _mm256_min_ps, _mm256_mul_pd,
-    _mm256_mul_ps, _mm256_or_pd, _mm256_or_ps, _mm256_set1_epi32, _mm256_set1_epi64x,
-    _mm256_set1_pd, _mm256_set1_ps, _mm256_store_pd, _mm256_store_ps, _mm256_storeu_pd,
-    _mm256_storeu_ps, _mm256_sub_pd, _mm256_sub_ps, _mm256_xor_pd, _mm256_xor_ps, _CMP_EQ_OQ,
-    _CMP_GT_OQ, _CMP_LT_OQ,
+    _mm256_loadu_ps, _mm256_min_pd, _mm256_min_ps, _mm256_mul_pd, _mm256_mul_ps, _mm256_or_pd,
+    _mm256_or_ps, _mm256_set1_epi32, _mm256_set1_epi64x, _mm256_set1_pd, _mm256_set1_ps,
+    _mm256_store_pd, _mm256_store_ps, _mm256_storeu_pd, _mm256_storeu_ps, _mm256_sub_pd,
+    _mm256_sub_ps, _mm256_xor_pd, _mm256_xor_ps, _CMP_EQ_OQ, _CMP_GT_OQ, _CMP_LT_OQ,
 };
 use std::mem;
 use std::ops::Neg;
@@ -16,6 +15,7 @@ use std::ops::Neg;
 use aligned::{Aligned, A32};
 use num_traits::{Float, Zero};
 
+use super::avx::{AVXVector32, AVXVector64};
 use super::SimdVector;
 use crate::vector::sse41::{SSE41Vector32, SSE41Vector64};
 
@@ -130,8 +130,8 @@ impl SimdVector for AVX2Vector32 {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_max_ps(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        AVXVector32::max(a, b)
     }
 
     #[target_feature(enable = "avx2")]
@@ -298,8 +298,8 @@ impl SimdVector for AVX2Vector64 {
     }
 
     #[target_feature(enable = "avx")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_max_pd(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        AVXVector64::max(a, b)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/mod.rs
+++ b/simd-array/src/vector/mod.rs
@@ -63,6 +63,8 @@ pub trait SimdVector: Default + Send + Sync {
     /// Select bits which are set in `a` in `b` or otherwise `c`.
     unsafe fn bitwise_select(a: Self::Mask, b: Self::Float, c: Self::Float) -> Self::Float;
 
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float;
+
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float;
 
     unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float;

--- a/simd-array/src/vector/neon.rs
+++ b/simd-array/src/vector/neon.rs
@@ -65,6 +65,10 @@ impl SimdVector for NeonVector32 {
         vreinterpretq_f32_u32(r)
     }
 
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        vmaxq_f32(min, a)
+    }
+
     #[target_feature(enable = "neon")]
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float {
         // Negative zero has all bits unset, except the sign bit.
@@ -231,6 +235,10 @@ impl SimdVector for NeonVector64 {
         let c = vreinterpretq_u64_f64(c);
         let r = vorrq_u64(vandq_u64(a, b), vbicq_u64(c, a));
         vreinterpretq_f64_u64(r)
+    }
+
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        vmaxq_f64(min, a)
     }
 
     #[target_feature(enable = "neon")]

--- a/simd-array/src/vector/neon.rs
+++ b/simd-array/src/vector/neon.rs
@@ -128,7 +128,7 @@ impl SimdVector for NeonVector32 {
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
         vmaxq_f32(a, b)
     }
 
@@ -296,7 +296,7 @@ impl SimdVector for NeonVector64 {
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
         vmaxq_f64(a, b)
     }
 

--- a/simd-array/src/vector/scalar.rs
+++ b/simd-array/src/vector/scalar.rs
@@ -146,6 +146,10 @@ impl SimdVector for ScalarVector32 {
     ) -> Self::FloatScalar {
         super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
     }
+
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        min.max(a)
+    }
 }
 
 #[derive(Default)]
@@ -288,6 +292,10 @@ impl SimdVector for ScalarVector64 {
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
         super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+    }
+
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        min.max(a)
     }
 }
 

--- a/simd-array/src/vector/sse2.rs
+++ b/simd-array/src/vector/sse2.rs
@@ -1,11 +1,12 @@
 use std::arch::x86_64::{
     __m128, __m128d, __m128i, _mm_add_pd, _mm_add_ps, _mm_and_pd, _mm_and_ps, _mm_andnot_pd,
     _mm_andnot_ps, _mm_castsi128_pd, _mm_castsi128_ps, _mm_cmpeq_pd, _mm_cmpeq_ps, _mm_cmpgt_pd,
-    _mm_cmpgt_ps, _mm_cmplt_pd, _mm_cmplt_ps, _mm_cvtps_epi32, _mm_cvtsd_f64, _mm_cvtss_f32,
-    _mm_div_pd, _mm_div_ps, _mm_load_pd, _mm_load_ps, _mm_load_si128, _mm_loadu_pd, _mm_loadu_ps,
-    _mm_max_pd, _mm_max_ps, _mm_min_pd, _mm_min_ps, _mm_movehdup_ps, _mm_movehl_ps, _mm_mul_pd,
-    _mm_mul_ps, _mm_or_pd, _mm_or_ps, _mm_set1_pd, _mm_set1_ps, _mm_store_pd, _mm_store_ps,
-    _mm_storeu_pd, _mm_storeu_ps, _mm_sub_pd, _mm_sub_ps, _mm_unpackhi_pd, _mm_xor_pd, _mm_xor_ps,
+    _mm_cmpgt_ps, _mm_cmplt_pd, _mm_cmplt_ps, _mm_cmpunord_pd, _mm_cmpunord_ps, _mm_cvtps_epi32,
+    _mm_cvtsd_f64, _mm_cvtss_f32, _mm_div_pd, _mm_div_ps, _mm_load_pd, _mm_load_ps, _mm_load_si128,
+    _mm_loadu_pd, _mm_loadu_ps, _mm_max_pd, _mm_max_ps, _mm_min_pd, _mm_min_ps, _mm_movehdup_ps,
+    _mm_movehl_ps, _mm_mul_pd, _mm_mul_ps, _mm_or_pd, _mm_or_ps, _mm_set1_pd, _mm_set1_ps,
+    _mm_store_pd, _mm_store_ps, _mm_storeu_pd, _mm_storeu_ps, _mm_sub_pd, _mm_sub_ps,
+    _mm_unpackhi_pd, _mm_xor_pd, _mm_xor_ps,
 };
 use std::mem;
 use std::ops::Neg;
@@ -128,8 +129,10 @@ impl SimdVector for SSE2Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm_max_ps(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        let max = _mm_max_ps(a, b);
+        let is_nan = _mm_cmpunord_ps(a, b);
+        _mm_or_ps(max, is_nan)
     }
 
     #[target_feature(enable = "sse2")]
@@ -300,8 +303,10 @@ impl SimdVector for SSE2Vector64 {
     }
 
     #[target_feature(enable = "sse2")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm_max_pd(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        let max = _mm_max_pd(a, b);
+        let is_nan = _mm_cmpunord_pd(a, b);
+        _mm_or_pd(max, is_nan)
     }
 
     #[target_feature(enable = "sse2")]

--- a/simd-array/src/vector/sse2.rs
+++ b/simd-array/src/vector/sse2.rs
@@ -63,6 +63,11 @@ impl SimdVector for SSE2Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        _mm_max_ps(min, a)
+    }
+
+    #[target_feature(enable = "sse2")]
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float {
         let sign_bit_mask = Self::splat(Self::FloatScalar::zero().neg());
         Self::bitwise_select(sign_bit_mask, sign_src, dest)
@@ -234,6 +239,11 @@ impl SimdVector for SSE2Vector64 {
         let u = _mm_and_pd(a, b);
         let v = _mm_andnot_pd(a, c);
         _mm_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "sse2")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        _mm_max_pd(min, a)
     }
 
     #[target_feature(enable = "sse2")]

--- a/simd-array/src/vector/sse41.rs
+++ b/simd-array/src/vector/sse41.rs
@@ -3,9 +3,9 @@ use std::arch::x86_64::{
     _mm_andnot_ps, _mm_castsi128_pd, _mm_castsi128_ps, _mm_cmpeq_pd, _mm_cmpeq_ps, _mm_cmpgt_pd,
     _mm_cmpgt_ps, _mm_cmplt_pd, _mm_cmplt_ps, _mm_cvtps_epi32, _mm_cvtsd_f64, _mm_cvtss_f32,
     _mm_div_pd, _mm_div_ps, _mm_floor_pd, _mm_floor_ps, _mm_load_si128, _mm_loadu_pd, _mm_loadu_ps,
-    _mm_max_pd, _mm_max_ps, _mm_min_pd, _mm_min_ps, _mm_movehdup_ps, _mm_movehl_ps, _mm_mul_pd,
-    _mm_mul_ps, _mm_or_pd, _mm_or_ps, _mm_set1_pd, _mm_set1_ps, _mm_store_pd, _mm_store_ps,
-    _mm_storeu_pd, _mm_storeu_ps, _mm_sub_pd, _mm_sub_ps, _mm_unpackhi_pd, _mm_xor_pd, _mm_xor_ps,
+    _mm_min_pd, _mm_min_ps, _mm_movehdup_ps, _mm_movehl_ps, _mm_mul_pd, _mm_mul_ps, _mm_or_pd,
+    _mm_or_ps, _mm_set1_pd, _mm_set1_ps, _mm_store_pd, _mm_store_ps, _mm_storeu_pd, _mm_storeu_ps,
+    _mm_sub_pd, _mm_sub_ps, _mm_unpackhi_pd, _mm_xor_pd, _mm_xor_ps,
 };
 use std::mem;
 use std::ops::Neg;
@@ -15,6 +15,8 @@ use num_traits::{Float, Zero};
 
 use crate::vector::scalar::{ScalarVector32, ScalarVector64};
 use crate::vector::SimdVector;
+
+use super::sse2::{SSE2Vector32, SSE2Vector64};
 
 #[derive(Default)]
 pub struct SSE41Vector32;
@@ -124,8 +126,8 @@ impl SimdVector for SSE41Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm_max_ps(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        SSE2Vector32::max(a, b)
     }
 
     #[target_feature(enable = "sse2")]
@@ -292,8 +294,8 @@ impl SimdVector for SSE41Vector64 {
     }
 
     #[target_feature(enable = "sse2")]
-    unsafe fn vmax(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm_max_pd(a, b)
+    unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
+        SSE2Vector64::max(a, b)
     }
 
     #[target_feature(enable = "sse2")]

--- a/simd-array/src/vector/sse41.rs
+++ b/simd-array/src/vector/sse41.rs
@@ -64,6 +64,11 @@ impl SimdVector for SSE41Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        SSE2Vector32::clamp_min(a, min)
+    }
+
+    #[target_feature(enable = "sse2")]
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float {
         let sign_bit_mask = Self::splat(Self::FloatScalar::zero().neg());
         Self::bitwise_select(sign_bit_mask, sign_src, dest)
@@ -229,6 +234,11 @@ impl SimdVector for SSE41Vector64 {
         let u = _mm_and_pd(a, b);
         let v = _mm_andnot_pd(a, c);
         _mm_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "sse2")]
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        SSE2Vector64::clamp_min(a, min)
     }
 
     #[target_feature(enable = "sse2")]


### PR DESCRIPTION
In machine learning this is what we typically want -- if a NaN shows up somewhere, propagate it, so that it becomes visible.

NaN-propagation is what we probably want in functions like max-reduction (if one of the numbers is NaN, the result of the reduction should probably be NaN).

~This is still a draft, because I am unhappy about what this does to other functions. E.g., this changes x86_64 ReLU from a single `max` instruction to `max`/`cmp`/`or`. However, we could rely on the behavior of max that the second operand is written to the destination under presence of NaN. However, these things become a bit icky with differences between instruction sets.~

The prior issue is fixed by adding a `SIMDVector::clamp_min` method. This method can do whatever is necessary to ensure that a NaN in the clamped values is propagated. In the case of NEON and SSE/AVX, this can be done in a single instruction. `clamp_min` is now used by the ReLU and clipped linear activations.