### PR TITLE
Add `Array::softmax` and `RustOps::softmax`

### DIFF
--- a/simd-array/src/vector/avx.rs
+++ b/simd-array/src/vector/avx.rs
@@ -196,7 +196,7 @@ impl SimdVector for AVXVector32 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }
 
@@ -382,6 +382,6 @@ impl SimdVector for AVXVector64 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }

--- a/simd-array/src/vector/avx2.rs
+++ b/simd-array/src/vector/avx2.rs
@@ -194,7 +194,7 @@ impl SimdVector for AVX2Vector32 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }
 
@@ -377,6 +377,6 @@ impl SimdVector for AVX2Vector64 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }

--- a/simd-array/src/vector/mod.rs
+++ b/simd-array/src/vector/mod.rs
@@ -69,6 +69,11 @@ pub trait SimdVector: Default + Send + Sync {
 
     unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float;
 
+    unsafe fn div_scalar(a: Self::Float, b: Self::FloatScalar) -> Self::Float {
+        let b = Self::splat(b);
+        Self::div(a, b)
+    }
+
     /// Fused mutiply-add, a * b + c
     unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float;
 
@@ -111,6 +116,11 @@ pub trait SimdVector: Default + Send + Sync {
     unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float;
 
     unsafe fn splat(v: Self::FloatScalar) -> Self::Float;
+
+    unsafe fn sub_scalar(a: Self::Float, b: Self::FloatScalar) -> Self::Float {
+        let b = Self::splat(b);
+        Self::sub(a, b)
+    }
 
     unsafe fn reinterpret_float_signed(v: Self::Int) -> Self::Float;
 

--- a/simd-array/src/vector/neon.rs
+++ b/simd-array/src/vector/neon.rs
@@ -191,7 +191,7 @@ impl SimdVector for NeonVector32 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }
 
@@ -368,6 +368,6 @@ impl SimdVector for NeonVector64 {
         init: f64,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }

--- a/simd-array/src/vector/scalar.rs
+++ b/simd-array/src/vector/scalar.rs
@@ -147,7 +147,7 @@ impl SimdVector for ScalarVector32 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
@@ -298,7 +298,7 @@ impl SimdVector for ScalarVector64 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {

--- a/simd-array/src/vector/sse2.rs
+++ b/simd-array/src/vector/sse2.rs
@@ -202,7 +202,7 @@ impl SimdVector for SSE2Vector32 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }
 
@@ -390,6 +390,6 @@ impl SimdVector for SSE2Vector64 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }

--- a/simd-array/src/vector/sse41.rs
+++ b/simd-array/src/vector/sse41.rs
@@ -194,7 +194,7 @@ impl SimdVector for SSE41Vector32 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }
 
@@ -376,6 +376,6 @@ impl SimdVector for SSE41Vector64 {
         init: Self::FloatScalar,
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
-        super::reduce_generic(Self, f, f_lanes, f_rest, init, a)
+        reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
 }


### PR DESCRIPTION
This initial version only supports `axis = -1`.

Also replace `reduce_generic` by a macro. Since the `reduce_generic` function does not have a `target_feature` attribute, we often end up with loops where the intrinsics are not inlined. Replace the function by a macro, so that the loop is expanded into a method with `target_feature` and we get vectorized loops with inlined intrinstics.