### PR TITLE
Types refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,9 @@ version = "0.1.0"
 dependencies = [
  "aligned",
  "as-slice",
+ "ndarray",
  "num-traits",
+ "thiserror",
 ]
 
 [[package]]

--- a/simd-array/Cargo.toml
+++ b/simd-array/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 [dependencies]
 aligned = "0.4"
 as-slice = "0.2"
+ndarray = "0.15"
 num-traits = "0.2"
+thiserror = "1"
 
 [dev-dependencies]
 approx = "0.5"

--- a/simd-array/src/array.rs
+++ b/simd-array/src/array.rs
@@ -1,0 +1,131 @@
+use ndarray::{ArrayBase, DataMut, Dimension};
+use num_traits::Float;
+use thiserror::Error;
+
+use crate::slice::PlatformSimdSlice;
+
+#[derive(Debug, Error)]
+pub enum SimdArrayError {
+    #[error("array is not contiguous")]
+    NonContiguous,
+}
+
+pub trait SimdArrayMut {
+    type Elem;
+
+    /// Clipped linear function.
+    fn clipped_linear(
+        &mut self,
+        slope: Self::Elem,
+        offset: Self::Elem,
+        min_val: Self::Elem,
+        max_val: Self::Elem,
+    ) -> Result<(), SimdArrayError>;
+
+    /// Gaussian error linear unit (GELU).
+    fn gelu(&mut self) -> Result<(), SimdArrayError>;
+
+    /// Hard sigmoid.
+    fn hard_sigmoid(&mut self) -> Result<(), SimdArrayError>;
+
+    /// Hard hyperbolic tangent.
+    fn hard_tanh(&mut self) -> Result<(), SimdArrayError>;
+
+    /// Logistic cumulative density function.
+    fn logistic_cdf(&mut self) -> Result<(), SimdArrayError>;
+
+    /// Rectified linear unit (ReLU).
+    fn relu(&mut self) -> Result<(), SimdArrayError>;
+
+    /// Softmax.
+    fn softmax(
+        &mut self,
+        n_class: usize,
+        temperature: Option<Self::Elem>,
+    ) -> Result<(), SimdArrayError>;
+
+    /// Swish activation.
+    fn swish(&mut self) -> Result<(), SimdArrayError>;
+}
+
+impl<S, D, A> SimdArrayMut for ArrayBase<S, D>
+where
+    S: DataMut<Elem = A>,
+    D: Dimension,
+    A: Float + PlatformSimdSlice,
+{
+    type Elem = A;
+
+    fn clipped_linear(
+        &mut self,
+        slope: Self::Elem,
+        offset: Self::Elem,
+        min_val: Self::Elem,
+        max_val: Self::Elem,
+    ) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().clipped_linear(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+            slope,
+            offset,
+            min_val,
+            max_val,
+        ))
+    }
+
+    fn gelu(&mut self) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().gelu(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+        ))
+    }
+
+    fn hard_sigmoid(&mut self) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().hard_sigmoid(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+        ))
+    }
+
+    fn hard_tanh(&mut self) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().hard_tanh(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+        ))
+    }
+
+    fn logistic_cdf(&mut self) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().logistic_cdf(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+        ))
+    }
+
+    fn relu(&mut self) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().relu(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+        ))
+    }
+
+    /// Softmax.
+    fn softmax(
+        &mut self,
+        n_class: usize,
+        temperature: Option<Self::Elem>,
+    ) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().softmax(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+            n_class,
+            temperature,
+        ))
+    }
+
+    fn swish(&mut self) -> Result<(), SimdArrayError> {
+        Ok(A::simd_slice().swish(
+            self.as_slice_memory_order_mut()
+                .ok_or(SimdArrayError::NonContiguous)?,
+        ))
+    }
+}

--- a/simd-array/src/lib.rs
+++ b/simd-array/src/lib.rs
@@ -5,7 +5,7 @@ mod distribution;
 mod elementary;
 
 mod slice;
-pub use slice::{all_platform_arrays, platform_arrays, SimdSlice};
+pub use slice::{all_platform_arrays, PlatformSimdSlice, SimdSlice};
 
 pub(crate) mod util;
 

--- a/simd-array/src/lib.rs
+++ b/simd-array/src/lib.rs
@@ -1,11 +1,11 @@
 pub(crate) mod activation;
 
-mod array;
-pub use array::{all_platform_arrays, platform_arrays, Array};
-
 mod distribution;
 
 mod elementary;
+
+mod slice;
+pub use slice::{all_platform_arrays, platform_arrays, SimdSlice};
 
 pub(crate) mod util;
 

--- a/simd-array/src/lib.rs
+++ b/simd-array/src/lib.rs
@@ -1,11 +1,14 @@
 pub(crate) mod activation;
 
+mod array;
+pub use array::{SimdArrayError, SimdArrayMut};
+
 mod distribution;
 
 mod elementary;
 
-mod slice;
-pub use slice::{all_platform_arrays, PlatformSimdSlice, SimdSlice};
+pub(crate) mod slice;
+pub use slice::all_platform_arrays;
 
 pub(crate) mod util;
 

--- a/simd-array/src/slice.rs
+++ b/simd-array/src/slice.rs
@@ -98,15 +98,12 @@ pub fn all_platform_arrays() -> HashMap<
 }
 
 pub trait PlatformSimdSlice {
-    type Scalar;
-    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self::Scalar>>;
+    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self>>;
 }
 
 #[cfg(target_arch = "aarch64")]
 impl PlatformSimdSlice for f32 {
-    type Scalar = f32;
-
-    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self::Scalar>> {
+    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self>> {
         if is_aarch64_feature_detected!("neon") {
             Box::new(NeonVector32)
         } else {
@@ -117,9 +114,7 @@ impl PlatformSimdSlice for f32 {
 
 #[cfg(target_arch = "aarch64")]
 impl PlatformSimdSlice for f64 {
-    type Scalar = f64;
-
-    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self::Scalar>> {
+    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self>> {
         if is_aarch64_feature_detected!("neon") {
             Box::new(NeonVector64)
         } else {
@@ -130,9 +125,7 @@ impl PlatformSimdSlice for f64 {
 
 #[cfg(target_arch = "x86_64")]
 impl PlatformSimdSlice for f32 {
-    type Scalar = f32;
-
-    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self::Scalar>> {
+    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self>> {
         if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
             Box::new(AVX2Vector32)
         } else if is_x86_feature_detected!("avx") {
@@ -149,9 +142,7 @@ impl PlatformSimdSlice for f32 {
 
 #[cfg(target_arch = "x86_64")]
 impl PlatformSimdSlice for f64 {
-    type Scalar = f64;
-
-    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self::Scalar>> {
+    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self>> {
         if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
             Box::new(AVX2Vector64)
         } else if is_x86_feature_detected!("avx") {
@@ -168,9 +159,7 @@ impl PlatformSimdSlice for f64 {
 
 #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
 impl PlatformSimdSlice for f32 {
-    type Scalar = f32;
-
-    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self::Scalar>> {
+    fn simd_slice() -> Box<dyn SimdSlice<Scalar = Self>> {
         Box::new(ScalarVector32)
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3,7 +3,7 @@ use numpy::{PyArray2, PyArrayDyn, PyReadonlyArray2};
 use pyo3::exceptions::PyValueError;
 use pyo3::{pyclass, pymethods, FromPyObject, IntoPy, PyObject, PyResult, Python};
 
-use simd_array::{platform_arrays, SimdSlice};
+use simd_array::{PlatformSimdSlice, SimdSlice};
 
 #[derive(FromPyObject)]
 enum PyArrayDynFloat<'a> {
@@ -50,10 +50,9 @@ pub struct RustOps {
 impl RustOps {
     #[new]
     fn new() -> Self {
-        let (array_f32, array_f64) = platform_arrays();
         RustOps {
-            array_f32,
-            array_f64,
+            array_f32: f32::simd_slice(),
+            array_f64: f64::simd_slice(),
         }
     }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3,7 +3,7 @@ use numpy::{PyArray2, PyArrayDyn, PyReadonlyArray2};
 use pyo3::exceptions::PyValueError;
 use pyo3::{pyclass, pymethods, FromPyObject, IntoPy, PyObject, PyResult, Python};
 
-use simd_array::{platform_arrays, Array};
+use simd_array::{platform_arrays, SimdSlice};
 
 #[derive(FromPyObject)]
 enum PyArrayDynFloat<'a> {
@@ -42,8 +42,8 @@ impl<'a> IntoPy<PyObject> for PyArrayDynFloat<'a> {
 
 #[pyclass(subclass)]
 pub struct RustOps {
-    array_f32: Box<dyn Array<Scalar = f32>>,
-    array_f64: Box<dyn Array<Scalar = f64>>,
+    array_f32: Box<dyn SimdSlice<Scalar = f32>>,
+    array_f64: Box<dyn SimdSlice<Scalar = f64>>,
 }
 
 #[pymethods]


### PR DESCRIPTION
* Rename `Array` to `SimdSlice`
* Replace `platform_arrays` by `PlatformSimdSlice` trait.
* Add the `SimdArrayMut` trait and use it in `RustOps`.

Fixes #44 