### PR TITLE
Add  `SimdSlice::min` reduction

### DIFF
--- a/simd-array/benches/slice.rs
+++ b/simd-array/benches/slice.rs
@@ -37,10 +37,19 @@ fn max_benchmark(c: &mut Criterion) {
     });
 }
 
+fn min_benchmark(c: &mut Criterion) {
+    reduction_benchmark::<f32, _>(c, "min f32", |simd_slice, slice| {
+        simd_slice.min(slice).unwrap()
+    });
+    reduction_benchmark::<f64, _>(c, "min f64", |simd_slice, slice| {
+        simd_slice.min(slice).unwrap()
+    });
+}
+
 fn sum_benchmark(c: &mut Criterion) {
     reduction_benchmark::<f32, _>(c, "sum f32", |simd_slice, slice| simd_slice.sum(slice));
     reduction_benchmark::<f64, _>(c, "sum f64", |simd_slice, slice| simd_slice.sum(slice));
 }
 
-criterion_group!(slice, max_benchmark, sum_benchmark);
+criterion_group!(slice, max_benchmark, min_benchmark, sum_benchmark);
 criterion_main!(slice);

--- a/simd-array/src/activation.rs
+++ b/simd-array/src/activation.rs
@@ -47,7 +47,7 @@ where
         let x_min_val = V::splat(min_val);
         let x_max_val = V::splat(max_val);
         let x = V::add_scalar(V::mul_scalar(x, slope), offset);
-        V::vmin(V::clamp_min(x, x_min_val), x_max_val)
+        V::clamp_max(V::clamp_min(x, x_min_val), x_max_val)
     }
 
     #[inline(always)]

--- a/simd-array/src/util.rs
+++ b/simd-array/src/util.rs
@@ -17,3 +17,21 @@ pub fn maximum<F: Float>(a: F, b: F) -> F {
         a + b
     }
 }
+
+// NaN-propagating minimum like {f32,f64}::minimum. Replace once
+// these are stabilized.
+pub fn minimum<F: Float>(a: F, b: F) -> F {
+    if a < b {
+        a
+    } else if b < a {
+        b
+    } else if a == b {
+        if a.is_sign_negative() && b.is_sign_positive() {
+            a
+        } else {
+            b
+        }
+    } else {
+        a + b
+    }
+}

--- a/simd-array/src/vector/avx.rs
+++ b/simd-array/src/vector/avx.rs
@@ -123,6 +123,12 @@ impl SimdVector for AVXVector32 {
     }
 
     #[target_feature(enable = "avx")]
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        let sums = Self::Lower::min(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 1));
+        Self::Lower::min_lanes(sums)
+    }
+
+    #[target_feature(enable = "avx")]
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         _mm256_mul_ps(a, b)
     }
@@ -152,8 +158,10 @@ impl SimdVector for AVXVector32 {
     }
 
     #[target_feature(enable = "avx")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_min_ps(a, b)
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        let min = _mm256_min_ps(a, b);
+        let is_nan = _mm256_cmp_ps::<_CMP_UNORD_Q>(a, b);
+        _mm256_or_ps(min, is_nan)
     }
 
     #[target_feature(enable = "avx")]
@@ -309,6 +317,12 @@ impl SimdVector for AVXVector64 {
     }
 
     #[target_feature(enable = "avx")]
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        let sums = Self::Lower::min(_mm256_castpd256_pd128(a), _mm256_extractf128_pd(a, 1));
+        Self::Lower::min_lanes(sums)
+    }
+
+    #[target_feature(enable = "avx")]
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         _mm256_mul_pd(a, b)
     }
@@ -338,8 +352,10 @@ impl SimdVector for AVXVector64 {
     }
 
     #[target_feature(enable = "avx")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_min_pd(a, b)
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        let min = _mm256_min_pd(a, b);
+        let is_nan = _mm256_cmp_pd::<_CMP_UNORD_Q>(a, b);
+        _mm256_or_pd(min, is_nan)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/avx.rs
+++ b/simd-array/src/vector/avx.rs
@@ -65,6 +65,11 @@ impl SimdVector for AVXVector32 {
     }
 
     #[target_feature(enable = "avx")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        _mm256_min_ps(max, a)
+    }
+
+    #[target_feature(enable = "avx")]
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
         _mm256_max_ps(min, a)
     }
@@ -243,6 +248,11 @@ impl SimdVector for AVXVector64 {
         let u = _mm256_and_pd(a, b);
         let v = _mm256_andnot_pd(a, c);
         _mm256_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "avx")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        _mm256_min_pd(max, a)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/avx2.rs
+++ b/simd-array/src/vector/avx2.rs
@@ -4,10 +4,10 @@ use std::arch::x86_64::{
     _mm256_castsi256_pd, _mm256_castsi256_ps, _mm256_cmp_pd, _mm256_cmp_ps, _mm256_cvtps_epi32,
     _mm256_div_pd, _mm256_div_ps, _mm256_extractf128_pd, _mm256_extractf128_ps, _mm256_floor_pd,
     _mm256_floor_ps, _mm256_fmadd_pd, _mm256_fmadd_ps, _mm256_load_si256, _mm256_loadu_pd,
-    _mm256_loadu_ps, _mm256_min_pd, _mm256_min_ps, _mm256_mul_pd, _mm256_mul_ps, _mm256_or_pd,
-    _mm256_or_ps, _mm256_set1_epi32, _mm256_set1_epi64x, _mm256_set1_pd, _mm256_set1_ps,
-    _mm256_store_pd, _mm256_store_ps, _mm256_storeu_pd, _mm256_storeu_ps, _mm256_sub_pd,
-    _mm256_sub_ps, _mm256_xor_pd, _mm256_xor_ps, _CMP_EQ_OQ, _CMP_GT_OQ, _CMP_LT_OQ,
+    _mm256_loadu_ps, _mm256_mul_pd, _mm256_mul_ps, _mm256_or_pd, _mm256_or_ps, _mm256_set1_epi32,
+    _mm256_set1_epi64x, _mm256_set1_pd, _mm256_set1_ps, _mm256_store_pd, _mm256_store_ps,
+    _mm256_storeu_pd, _mm256_storeu_ps, _mm256_sub_pd, _mm256_sub_ps, _mm256_xor_pd, _mm256_xor_ps,
+    _CMP_EQ_OQ, _CMP_GT_OQ, _CMP_LT_OQ,
 };
 use std::mem;
 use std::ops::Neg;
@@ -122,6 +122,11 @@ impl SimdVector for AVX2Vector32 {
         AVXVector32::max_lanes(a)
     }
 
+    #[target_feature(enable = "avx")]
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        AVXVector32::min_lanes(a)
+    }
+
     #[target_feature(enable = "avx2")]
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         _mm256_mul_ps(a, b)
@@ -150,8 +155,8 @@ impl SimdVector for AVX2Vector32 {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_min_ps(a, b)
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        AVXVector32::min(a, b)
     }
 
     #[target_feature(enable = "avx2")]
@@ -306,6 +311,11 @@ impl SimdVector for AVX2Vector64 {
     }
 
     #[target_feature(enable = "avx")]
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        AVXVector64::min_lanes(a)
+    }
+
+    #[target_feature(enable = "avx")]
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         _mm256_mul_pd(a, b)
     }
@@ -333,8 +343,8 @@ impl SimdVector for AVX2Vector64 {
     }
 
     #[target_feature(enable = "avx")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm256_min_pd(a, b)
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        AVXVector64::min(a, b)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/avx2.rs
+++ b/simd-array/src/vector/avx2.rs
@@ -66,6 +66,11 @@ impl SimdVector for AVX2Vector32 {
     }
 
     #[target_feature(enable = "avx")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        AVXVector32::clamp_max(a, max)
+    }
+
+    #[target_feature(enable = "avx")]
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
         AVXVector32::clamp_min(a, min)
     }
@@ -241,6 +246,11 @@ impl SimdVector for AVX2Vector64 {
         let u = _mm256_and_pd(a, b);
         let v = _mm256_andnot_pd(a, c);
         _mm256_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "avx")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        AVXVector64::clamp_max(a, max)
     }
 
     #[target_feature(enable = "avx")]

--- a/simd-array/src/vector/mod.rs
+++ b/simd-array/src/vector/mod.rs
@@ -63,6 +63,10 @@ pub trait SimdVector: Default + Send + Sync {
     /// Select bits which are set in `a` in `b` or otherwise `c`.
     unsafe fn bitwise_select(a: Self::Mask, b: Self::Float, c: Self::Float) -> Self::Float;
 
+    /// Clamp values to the range `[,max]`.
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float;
+
+    /// Clamp values to the range `[min,]`.
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float;
 
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float;

--- a/simd-array/src/vector/mod.rs
+++ b/simd-array/src/vector/mod.rs
@@ -99,7 +99,15 @@ pub trait SimdVector: Default + Send + Sync {
     /// If a is less than b, set all corresponding lanes to 1.
     unsafe fn lt(a: Self::Float, b: Self::Float) -> Self::Mask;
 
+    /// Get the maximum of all lanes.
+    ///
+    /// All implementations must be NaN-propagating.
     unsafe fn max_lanes(a: Self::Float) -> Self::FloatScalar;
+
+    /// Get the minimum of all lanes.
+    ///
+    /// All implementations must be NaN-propagating.
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar;
 
     /// Vector element-wise multiplication.
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float;
@@ -117,7 +125,9 @@ pub trait SimdVector: Default + Send + Sync {
     unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float;
 
     /// Vector element-wise minimum.
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float;
+    ///
+    /// All implementations must be NaN-propagating.
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float;
 
     unsafe fn splat(v: Self::FloatScalar) -> Self::Float;
 

--- a/simd-array/src/vector/neon.rs
+++ b/simd-array/src/vector/neon.rs
@@ -65,6 +65,10 @@ impl SimdVector for NeonVector32 {
         vreinterpretq_f32_u32(r)
     }
 
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        vminq_f32(max, a)
+    }
+
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
         vmaxq_f32(min, a)
     }
@@ -82,13 +86,13 @@ impl SimdVector for NeonVector32 {
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn floor(a: Self::Float) -> Self::Float {
-        vrndmq_f32(a)
+    unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float {
+        vfmaq_f32(c, a, b)
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float {
-        vfmaq_f32(c, a, b)
+    unsafe fn floor(a: Self::Float) -> Self::Float {
+        vrndmq_f32(a)
     }
 
     #[target_feature(enable = "neon")]
@@ -242,6 +246,10 @@ impl SimdVector for NeonVector64 {
         vreinterpretq_f64_u64(r)
     }
 
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        vminq_f64(max, a)
+    }
+
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
         vmaxq_f64(min, a)
     }
@@ -259,13 +267,13 @@ impl SimdVector for NeonVector64 {
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn floor(a: Self::Float) -> Self::Float {
-        vrndmq_f64(a)
+    unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float {
+        vfmaq_f64(c, a, b)
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float {
-        vfmaq_f64(c, a, b)
+    unsafe fn floor(a: Self::Float) -> Self::Float {
+        vrndmq_f64(a)
     }
 
     #[target_feature(enable = "neon")]

--- a/simd-array/src/vector/neon.rs
+++ b/simd-array/src/vector/neon.rs
@@ -3,10 +3,10 @@ use std::arch::aarch64::{
     vaddq_f32, vaddq_f64, vaddvq_f32, vaddvq_f64, vandq_u32, vandq_u64, vbicq_u32, vbicq_u64,
     vceqq_f32, vceqq_f64, vcgtq_f32, vcgtq_f64, vcltq_f32, vcltq_f64, vcvtq_s32_f32, vcvtq_s64_f64,
     vdivq_f32, vdivq_f64, vdupq_n_f32, vdupq_n_f64, vfmaq_f32, vfmaq_f64, vld1q_f32, vld1q_f64,
-    vmaxq_f32, vmaxq_f64, vmaxvq_f32, vmaxvq_f64, vminq_f32, vminq_f64, vmulq_f32, vmulq_f64,
-    vnegq_f32, vnegq_f64, vorrq_u32, vorrq_u64, vreinterpretq_f32_s32, vreinterpretq_f32_u32,
-    vreinterpretq_f64_s64, vreinterpretq_f64_u64, vreinterpretq_u32_f32, vreinterpretq_u64_f64,
-    vrndmq_f32, vrndmq_f64, vst1q_f32, vst1q_f64, vsubq_f32, vsubq_f64,
+    vmaxq_f32, vmaxq_f64, vmaxvq_f32, vmaxvq_f64, vminq_f32, vminq_f64, vminvq_f32, vminvq_f64,
+    vmulq_f32, vmulq_f64, vnegq_f32, vnegq_f64, vorrq_u32, vorrq_u64, vreinterpretq_f32_s32,
+    vreinterpretq_f32_u32, vreinterpretq_f64_s64, vreinterpretq_f64_u64, vreinterpretq_u32_f32,
+    vreinterpretq_u64_f64, vrndmq_f32, vrndmq_f64, vst1q_f32, vst1q_f64, vsubq_f32, vsubq_f64,
 };
 use std::mem;
 use std::ops::Neg;
@@ -119,6 +119,10 @@ impl SimdVector for NeonVector32 {
         vmaxvq_f32(a)
     }
 
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        vminvq_f32(a)
+    }
+
     #[target_feature(enable = "neon")]
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         vmulq_f32(a, b)
@@ -146,7 +150,7 @@ impl SimdVector for NeonVector32 {
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
         vminq_f32(a, b)
     }
 
@@ -300,6 +304,10 @@ impl SimdVector for NeonVector64 {
         vmaxvq_f64(a)
     }
 
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        vminvq_f64(a)
+    }
+
     #[target_feature(enable = "neon")]
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         vmulq_f64(a, b)
@@ -327,7 +335,7 @@ impl SimdVector for NeonVector64 {
     }
 
     #[target_feature(enable = "neon")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
         vminq_f64(a, b)
     }
 

--- a/simd-array/src/vector/scalar.rs
+++ b/simd-array/src/vector/scalar.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use crate::util::maximum;
+use crate::util::{maximum, minimum};
 use crate::vector::{apply_elementwise_generic, SimdVector};
 
 #[derive(Default)]
@@ -92,6 +92,10 @@ impl SimdVector for ScalarVector32 {
         a
     }
 
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        a
+    }
+
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         a * b
     }
@@ -112,12 +116,8 @@ impl SimdVector for ScalarVector32 {
         maximum(a, b)
     }
 
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        if a > b {
-            b
-        } else {
-            a
-        }
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        minimum(a, b)
     }
 
     unsafe fn splat(v: f32) -> Self::Float {
@@ -248,6 +248,10 @@ impl SimdVector for ScalarVector64 {
         a
     }
 
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        a
+    }
+
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         a * b
     }
@@ -267,12 +271,8 @@ impl SimdVector for ScalarVector64 {
         maximum(a, b)
     }
 
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        if a > b {
-            b
-        } else {
-            a
-        }
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        minimum(a, b)
     }
 
     unsafe fn splat(v: f64) -> Self::Float {

--- a/simd-array/src/vector/scalar.rs
+++ b/simd-array/src/vector/scalar.rs
@@ -36,12 +36,24 @@ impl SimdVector for ScalarVector32 {
         Self::Float::from_bits((a & b.to_bits()) | ((!a) & c.to_bits()))
     }
 
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        max.min(a)
+    }
+
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        min.max(a)
+    }
+
     unsafe fn copy_sign(sign: Self::Float, dest: Self::Float) -> Self::Float {
         dest.copysign(sign)
     }
 
     unsafe fn div(a: Self::Float, b: Self::Float) -> Self::Float {
         a / b
+    }
+
+    unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float {
+        a * b + c
     }
 
     unsafe fn floor(a: Self::Float) -> Self::Float {
@@ -54,10 +66,6 @@ impl SimdVector for ScalarVector32 {
         } else {
             0
         }
-    }
-
-    unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float {
-        a * b + c
     }
 
     unsafe fn gt(a: Self::Float, b: Self::Float) -> Self::Mask {
@@ -149,10 +157,6 @@ impl SimdVector for ScalarVector32 {
     ) -> Self::FloatScalar {
         reduce_generic!(Self, f, f_lanes, f_rest, init, a)
     }
-
-    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
-        min.max(a)
-    }
 }
 
 #[derive(Default)]
@@ -188,6 +192,14 @@ impl SimdVector for ScalarVector64 {
         Self::Float::from_bits((a & b.to_bits()) | ((!a) & c.to_bits()))
     }
 
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        max.min(a)
+    }
+
+    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
+        min.max(a)
+    }
+
     unsafe fn copy_sign(sign_src: Self::Float, dest: Self::Float) -> Self::Float {
         dest.copysign(sign_src)
     }
@@ -196,12 +208,12 @@ impl SimdVector for ScalarVector64 {
         a / b
     }
 
-    unsafe fn floor(a: Self::Float) -> Self::Float {
-        a.floor()
-    }
-
     unsafe fn fma(a: Self::Float, b: Self::Float, c: Self::Float) -> Self::Float {
         a * b + c
+    }
+
+    unsafe fn floor(a: Self::Float) -> Self::Float {
+        a.floor()
     }
 
     unsafe fn eq(a: Self::Float, b: Self::Float) -> Self::Mask {
@@ -247,7 +259,6 @@ impl SimdVector for ScalarVector64 {
     unsafe fn neg(a: Self::Float) -> Self::Float {
         -a
     }
-
     unsafe fn sub(a: Self::Float, b: Self::Float) -> Self::Float {
         a - b
     }
@@ -255,6 +266,7 @@ impl SimdVector for ScalarVector64 {
     unsafe fn max(a: Self::Float, b: Self::Float) -> Self::Float {
         maximum(a, b)
     }
+
     unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
         if a > b {
             b
@@ -299,9 +311,5 @@ impl SimdVector for ScalarVector64 {
         a: &[Self::FloatScalar],
     ) -> Self::FloatScalar {
         reduce_generic!(Self, f, f_lanes, f_rest, init, a)
-    }
-
-    unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
-        min.max(a)
     }
 }

--- a/simd-array/src/vector/sse2.rs
+++ b/simd-array/src/vector/sse2.rs
@@ -64,6 +64,11 @@ impl SimdVector for SSE2Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        _mm_min_ps(max, a)
+    }
+
+    #[target_feature(enable = "sse2")]
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
         _mm_max_ps(min, a)
     }
@@ -247,6 +252,11 @@ impl SimdVector for SSE2Vector64 {
         let u = _mm_and_pd(a, b);
         let v = _mm_andnot_pd(a, c);
         _mm_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "sse2")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        _mm_min_pd(max, a)
     }
 
     #[target_feature(enable = "sse2")]

--- a/simd-array/src/vector/sse41.rs
+++ b/simd-array/src/vector/sse41.rs
@@ -64,6 +64,11 @@ impl SimdVector for SSE41Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        SSE2Vector32::clamp_max(a, max)
+    }
+
+    #[target_feature(enable = "sse2")]
     unsafe fn clamp_min(a: Self::Float, min: Self::Float) -> Self::Float {
         SSE2Vector32::clamp_min(a, min)
     }
@@ -239,6 +244,11 @@ impl SimdVector for SSE41Vector64 {
         let u = _mm_and_pd(a, b);
         let v = _mm_andnot_pd(a, c);
         _mm_or_pd(u, v)
+    }
+
+    #[target_feature(enable = "sse2")]
+    unsafe fn clamp_max(a: Self::Float, max: Self::Float) -> Self::Float {
+        SSE2Vector64::clamp_max(a, max)
     }
 
     #[target_feature(enable = "sse2")]

--- a/simd-array/src/vector/sse41.rs
+++ b/simd-array/src/vector/sse41.rs
@@ -3,9 +3,9 @@ use std::arch::x86_64::{
     _mm_andnot_ps, _mm_castsi128_pd, _mm_castsi128_ps, _mm_cmpeq_pd, _mm_cmpeq_ps, _mm_cmpgt_pd,
     _mm_cmpgt_ps, _mm_cmplt_pd, _mm_cmplt_ps, _mm_cvtps_epi32, _mm_cvtsd_f64, _mm_cvtss_f32,
     _mm_div_pd, _mm_div_ps, _mm_floor_pd, _mm_floor_ps, _mm_load_si128, _mm_loadu_pd, _mm_loadu_ps,
-    _mm_min_pd, _mm_min_ps, _mm_movehdup_ps, _mm_movehl_ps, _mm_mul_pd, _mm_mul_ps, _mm_or_pd,
-    _mm_or_ps, _mm_set1_pd, _mm_set1_ps, _mm_store_pd, _mm_store_ps, _mm_storeu_pd, _mm_storeu_ps,
-    _mm_sub_pd, _mm_sub_ps, _mm_unpackhi_pd, _mm_xor_pd, _mm_xor_ps,
+    _mm_movehdup_ps, _mm_movehl_ps, _mm_mul_pd, _mm_mul_ps, _mm_or_pd, _mm_or_ps, _mm_set1_pd,
+    _mm_set1_ps, _mm_store_pd, _mm_store_ps, _mm_storeu_pd, _mm_storeu_ps, _mm_sub_pd, _mm_sub_ps,
+    _mm_unpackhi_pd, _mm_xor_pd, _mm_xor_ps,
 };
 use std::mem;
 use std::ops::Neg;
@@ -120,6 +120,11 @@ impl SimdVector for SSE41Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        SSE2Vector32::min_lanes(a)
+    }
+
+    #[target_feature(enable = "sse2")]
     unsafe fn mul(a: Self::Float, b: Self::Float) -> Self::Float {
         _mm_mul_ps(a, b)
     }
@@ -146,8 +151,8 @@ impl SimdVector for SSE41Vector32 {
     }
 
     #[target_feature(enable = "sse2")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm_min_ps(a, b)
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        SSE2Vector32::min(a, b)
     }
 
     #[target_feature(enable = "sse2")]
@@ -298,6 +303,11 @@ impl SimdVector for SSE41Vector64 {
     }
 
     #[target_feature(enable = "sse2")]
+    unsafe fn min_lanes(a: Self::Float) -> Self::FloatScalar {
+        SSE2Vector64::min_lanes(a)
+    }
+
+    #[target_feature(enable = "sse2")]
     unsafe fn lt(a: Self::Float, b: Self::Float) -> Self::Mask {
         _mm_cmplt_pd(a, b)
     }
@@ -329,8 +339,8 @@ impl SimdVector for SSE41Vector64 {
     }
 
     #[target_feature(enable = "sse2")]
-    unsafe fn vmin(a: Self::Float, b: Self::Float) -> Self::Float {
-        _mm_min_pd(a, b)
+    unsafe fn min(a: Self::Float, b: Self::Float) -> Self::Float {
+        SSE2Vector64::min(a, b)
     }
 
     #[target_feature(enable = "sse2")]


### PR DESCRIPTION
Related changes:

- Rename `SimdVector::vmin` to `SimdVector::min` and make it check both operands for `NaN`.
- Introduce new `SimdVector::clamp_max` and use it in `clipped_linear` (in place of `vmin`/`min`).

Fixes #48 .