### PR TITLE
Expose SimdSlice and PlatformSimdSlice for benchmarks

### DIFF
--- a/simd-array/src/lib.rs
+++ b/simd-array/src/lib.rs
@@ -11,6 +11,9 @@ mod elementary;
 
 mod slice;
 
+#[doc(hidden)]
+pub use slice::{PlatformSimdSlice, SimdSlice};
+
 mod util;
 
 mod vector;


### PR DESCRIPTION
Hide these exports in rustdoc.
